### PR TITLE
Document 3.1.4 release (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to ReadingBat Core are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] (3.1.3)
+## [3.1.4] - 2026-04-25
+
+### Changed
+
+- Centralized repository declarations in `settings.gradle.kts` (`FAIL_ON_PROJECT_REPOS`)
+- Refactored root `build.gradle.kts` to scope Kotlin/publishing/lint/test config per-subproject via helpers
+- Bumped dependencies: Kotlin 2.3.21, Ktor 3.4.3, Exposed 1.2.0, Kotest 6.1.11, Kotlinter 5.4.2, Dokka 2.2.0, Postgres 42.7.10, Hikari 7.0.2, Flyway 12.4.0, Playwright 1.59.0, common-utils 2.8.1, plus other minor bumps
+- Cleaned up unused libraries from the version catalog
+- Bumped version to 3.1.4
+
+### Added
+
+- Playwright-based browser tests (`PlaywrightAuthTest`, `PlaywrightEndpointTest`) replacing legacy Cypress specs
+- `.claude/skills/playwright-cli/` documentation and references for Playwright CLI workflows
+
+### Removed
+
+- Legacy Cypress example specs, integration tests, fixtures, and `package.json`
+- Unused `EmailUtils.kt` and `Emailer.kt`
+
+## [3.1.3] - 2026-04-12
 
 ### Changed
 
@@ -133,7 +153,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Initial tracked release
 
-[Unreleased]: https://github.com/readingbat/readingbat-core/compare/3.0.11...HEAD
+[Unreleased]: https://github.com/readingbat/readingbat-core/compare/3.1.4...HEAD
+[3.1.4]: https://github.com/readingbat/readingbat-core/compare/3.1.3...3.1.4
+[3.1.3]: https://github.com/readingbat/readingbat-core/compare/3.1.2...3.1.3
 [3.0.11]: https://github.com/readingbat/readingbat-core/compare/3.0.10...3.0.11
 [3.0.10]: https://github.com/readingbat/readingbat-core/compare/3.0.9...3.0.10
 [3.0.9]: https://github.com/readingbat/readingbat-core/compare/3.0.8...3.0.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,9 @@ The `readingbat-kotest` module provides `TestSupport` with helpers:
 - `forEachLanguage` / `forEachGroup` / `forEachChallenge` — DSL for iterating content
 - `answerAllWith()` / `answerAllWithCorrectAnswer()` — integration test helpers for checking answers via HTTP
 - Test content is defined in `readingbat-core/src/test/kotlin/TestData.kt`
+- Browser tests use Playwright (`com.microsoft.playwright:playwright`) and live in
+  `readingbat-core/src/test/kotlin/com/readingbat/playwright/` (e.g., `PlaywrightAuthTest`, `PlaywrightEndpointTest`).
+  These replaced the old Cypress specs.
 
 ### Key Dependencies
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Kotlin-based framework for creating interactive programming challenges and edu
 
 ReadingBat Core is built using modern Kotlin technologies:
 
-- **Web Framework**: Ktor 3.4.2 with CIO engine
+- **Web Framework**: Ktor 3.4.3 with CIO engine
 - **Database**: PostgreSQL with Exposed ORM (`exposed-kotlin-datetime`) and HikariCP connection pooling
 - **Authentication**: OAuth (GitHub, Google) with session management
 - **Script Execution**: JSR-223 scripting engines for safe code evaluation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+# Release Notes
+
+## v3.1.4 — 2026-04-25
+
+Build modernization, dependency bumps, and frontend test migration from Cypress to Playwright.
+
+### Highlights
+
+- **Build refactor.** Repository declarations centralized in `settings.gradle.kts` with `FAIL_ON_PROJECT_REPOS`. Root `build.gradle.kts` now scopes Kotlin, publishing, lint, and test configuration per-subproject via small helper functions, making each subproject's build behavior easier to reason about.
+- **Dependency bumps.** Kotlin 2.3.21, Ktor 3.4.3, Exposed 1.2.0, Kotest 6.1.11, Kotlinter 5.4.2, Dokka 2.2.0, Postgres 42.7.10, Hikari 7.0.2, Flyway 12.4.0, Playwright 1.59.0, common-utils 2.8.1, plus other minor bumps. Unused entries removed from the version catalog.
+- **Playwright migration.** Replaced legacy Cypress example specs, integration tests, fixtures, and `package.json` with Kotlin-based Playwright tests (`PlaywrightAuthTest`, `PlaywrightEndpointTest`) running under Kotest.
+- **Cleanup.** Dropped unused `EmailUtils.kt` and `Emailer.kt`.
+
+**Full Changelog**: https://github.com/readingbat/readingbat-core/compare/3.1.3...3.1.4
+
+---
+
+For history prior to 3.1.4, see [CHANGELOG.md](CHANGELOG.md).

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ ReadingBat Core is a web application built with Ktor that serves programming cha
 
 ## Key Technologies
 
-- Kotlin 2.3.20, Ktor 3.4.2 (CIO engine), Exposed ORM 1.2.0 with kotlinx-datetime, PostgreSQL
+- Kotlin 2.3.21, Ktor 3.4.3 (CIO engine), Exposed ORM 1.2.0 with kotlinx-datetime, PostgreSQL
 - Kotlinx.html for server-side HTML generation (no templates)
 - Kotest for testing, Playwright for E2E tests
 - Gradle multi-module build with version catalog (libs.versions.toml)


### PR DESCRIPTION
## Summary
- Promote prior `[Unreleased] (3.1.3)` section in `CHANGELOG.md` to `[3.1.3] - 2026-04-12` and add a new `[3.1.4] - 2026-04-25` entry covering PR #83 (build refactor, dep bumps, Cypress→Playwright migration, cleanup)
- Add `RELEASE_NOTES.md` with v3.1.4 highlights and changelog compare link
- Bump Kotlin/Ktor versions referenced in `README.md` and `llms.txt` to match the catalog (Kotlin 2.3.21, Ktor 3.4.3)
- Note Playwright test location in `CLAUDE.md`

## Test plan
- [ ] Visual review of CHANGELOG, RELEASE_NOTES, CLAUDE.md, README.md, llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)