### PR TITLE
Release 3.1.6: early health route, releaseDate fallback, Kover 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to ReadingBat Core are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.1.6] - 2026-05-03
+
+### Changed
+
+- Health/liveness route (`/ping`) split out of `adminRoutes` into a new `healthRoutes` and registered in `Application.module()` before `readContentDsl(...)`, so probes succeed while GitHub-backed content is still loading
+- `TestSupport` updated to mirror the new health route registration order
+- `releaseDate` resolution in `readingbat-core/build.gradle.kts` softened: falls back to today's date when the gradle property is absent or blank instead of erroring
+- Removed now-redundant `releaseDate` from `gradle.properties`
+- Hoisted `DokkaExtension` import and added explicit types in `readingbat-core/build.gradle.kts` for clarity
+- Bumped Kover to 0.9.8
+- Bumped version to 3.1.6
+
 ## [3.1.5] - 2026-05-03
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## v3.1.6 — 2026-05-03
+
+Health-check routing fix, build-script polish, and a Kover patch bump.
+
+### Highlights
+
+- **Health route registered early.** The `/ping` endpoint is now split out of `adminRoutes` into a dedicated `healthRoutes` function and wired into `Application.module()` before `readContentDsl(...)` runs. Liveness/readiness probes succeed while GitHub-backed content is still loading, so platforms that gate traffic on `/ping` no longer black-hole during cold starts. `TestSupport` mirrors the new registration order.
+- **`releaseDate` fallback.** `releaseDate` resolution in `readingbat-core/build.gradle.kts` now falls back to today's date when the gradle property is missing or blank, instead of failing the build. The corresponding `releaseDate=` line was dropped from `gradle.properties`.
+- **Build-script polish.** Hoisted the `DokkaExtension` import and added explicit types in `readingbat-core/build.gradle.kts` to keep the file readable as it grows.
+- **Kover 0.9.8.** Patch bump from 0.9.1.
+
+**Full Changelog**: https://github.com/readingbat/readingbat-core/compare/3.1.5...3.1.6
+
+---
+
 ## v3.1.5 — 2026-05-03
 
 Gradle 9.5.0 upgrade, Kover code coverage, Codecov integration, and a focused round of build-script hardening.
@@ -31,4 +46,4 @@ Build modernization, dependency bumps, and frontend test migration from Cypress 
 
 ---
 
-For history prior to 3.1.5, see [CHANGELOG.md](CHANGELOG.md).
+For history prior to 3.1.6, see [CHANGELOG.md](CHANGELOG.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.1.5
+version=3.1.6
 releaseDate=05/03/2026
 
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 group=com.readingbat
 version=3.1.6
-releaseDate=05/03/2026
 
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 buildconfig = "6.0.9"
 kotlin = "2.3.21"
 kotlinter = "5.4.2"
-kover = "0.9.1"
+kover = "0.9.8"
 dokka = "2.2.0"
 maven-publish = "0.36.0"
 versions = "0.54.0"

--- a/readingbat-core/build.gradle.kts
+++ b/readingbat-core/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 plugins {
   application
   alias(libs.plugins.buildconfig)
@@ -47,8 +50,8 @@ dependencies {
   testImplementation(project(":readingbat-kotest"))
 }
 
-val releaseDate = providers.gradleProperty("releaseDate").orNull
-  ?: error("releaseDate not set in gradle.properties")
+val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+val releaseDate = (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
 val buildTime = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
 
 buildConfig {

--- a/readingbat-core/build.gradle.kts
+++ b/readingbat-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -50,9 +51,10 @@ dependencies {
   testImplementation(project(":readingbat-kotest"))
 }
 
-val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate = (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
-val buildTime = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
+val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+val releaseDate: String =
+  (findProperty("releaseDate") as? String)?.takeIf { it.isNotBlank() } ?: LocalDate.now().format(formatter)
+val buildTime: Long = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
 
 buildConfig {
   packageName("com.readingbat")
@@ -64,7 +66,7 @@ buildConfig {
 }
 
 // Exclude top-level entry points from KDocs
-extensions.configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+extensions.configure<DokkaExtension> {
   dokkaSourceSets.configureEach {
     suppressedFiles.from(
       "src/main/kotlin/Content.kt",

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
@@ -55,6 +55,7 @@ import com.readingbat.server.ReadingBatServer.metrics
 import com.readingbat.server.ReadingBatServer.start
 import com.readingbat.server.ServerUtils.logToShim
 import com.readingbat.server.routes.AdminRoutes.adminRoutes
+import com.readingbat.server.routes.AdminRoutes.healthRoutes
 import com.readingbat.server.routes.oauthRoutes
 import com.readingbat.server.routes.sysAdminRoutes
 import com.readingbat.server.routes.userRoutes
@@ -285,6 +286,11 @@ fun Application.module() {
 
   val dslFileName = Property.DSL_FILE_NAME.getRequiredProperty()
   val dslVariableName = Property.DSL_VARIABLE_NAME.getRequiredProperty()
+
+  // Initialize this early so that we do not fail the health check while loading the GitHub content
+  routing {
+    healthRoutes(metrics)
+  }
 
   val job = launch { readContentDsl(dslFileName, dslVariableName) }
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/AdminRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/AdminRoutes.kt
@@ -36,6 +36,7 @@ import com.readingbat.server.BrowserSessionsTable
 import com.readingbat.server.GeoInfo.Companion.lookupGeoInfo
 import com.readingbat.server.ServerUtils.fetchUser
 import com.readingbat.server.ServerUtils.get
+import com.readingbat.server.routes.AdminRoutes.assignBrowserSession
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.ContentType.Text.Plain
 import io.ktor.http.HttpStatusCode
@@ -79,11 +80,13 @@ object AdminRoutes {
     return true
   }
 
-  fun Routing.adminRoutes(metrics: Metrics) {
+  fun Routing.healthRoutes(metrics: Metrics) {
     get(PING_ENDPOINT, metrics) {
       call.respondText("pong", Plain)
     }
+  }
 
+  fun Routing.adminRoutes(metrics: Metrics) {
     get(THREAD_DUMP, metrics) {
       if (!requireAdminUser()) return@get
 

--- a/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
+++ b/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
@@ -37,6 +37,7 @@ import com.readingbat.server.Installs.installs
 import com.readingbat.server.Locations.locations
 import com.readingbat.server.ReadingBatServer
 import com.readingbat.server.routes.AdminRoutes.adminRoutes
+import com.readingbat.server.routes.AdminRoutes.healthRoutes
 import com.readingbat.server.routes.sysAdminRoutes
 import com.readingbat.server.routes.userRoutes
 import com.readingbat.server.ws.WsCommon.wsRoutes
@@ -193,6 +194,7 @@ object TestSupport {
     installs(production)
 
     routing {
+      healthRoutes(ReadingBatServer.metrics)
       adminRoutes(ReadingBatServer.metrics)
       locations(ReadingBatServer.metrics) { content }
       userRoutes(ReadingBatServer.metrics) { content }


### PR DESCRIPTION
## Summary

- Split `/ping` out of `adminRoutes` into a new `healthRoutes` and register it in `Application.module()` *before* `readContentDsl(...)` so liveness/readiness probes succeed during cold starts while GitHub-backed content is still loading. `TestSupport` mirrors the new registration order.
- Soften `releaseDate` resolution in `readingbat-core/build.gradle.kts`: fall back to today's date when the gradle property is absent or blank instead of failing the build. Drop the now-redundant `releaseDate` line from `gradle.properties`.
- Hoist the `DokkaExtension` import and add explicit types in `readingbat-core/build.gradle.kts`.
- Bump Kover 0.9.1 → 0.9.8.
- Bump project version to 3.1.6 and document the release in `CHANGELOG.md` / `RELEASE_NOTES.md`.

## Test plan

- [ ] `./gradlew build` passes
- [ ] `./gradlew check` passes
- [ ] `./gradlew koverHtmlReport` produces `build/reports/kover/html/index.html`
- [ ] `curl -fsS http://localhost:8080/ping` returns 200 immediately on app boot, before content DSL has finished loading
- [ ] `./gradlew :readingbat-core:processResources` succeeds with `releaseDate` removed from `gradle.properties` (uses today's date fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)