### PR TITLE
Load DSL content in the background; gate routes with a loading page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to ReadingBat Core are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.1.7] - 2026-05-04
+
+### Changed
+
+- `Application.module()` no longer blocks on `readContentDsl(...)`. The DSL load runs on `Dispatchers.IO` so the Ktor engine starts serving immediately and platform health checks (`/ping`) are reachable during cold starts
+- New `Plugins`-phase interceptor in `Intercepts.kt` returns `503 Service Unavailable` + `Retry-After` and a cached `ContentLoadingPage` for any user-facing path until the first DSL load completes; `/ping`, `/static/*`, favicon, and robots stay available
+- Replaced the one-shot `STARTUP_DELAY_SECS` warning with a 10-second polling loop that logs `Content not loaded after Ns` until the load finishes
+- `ContentLoadingPage` HTML built once via `by lazy`; the meta-refresh interval and the `Retry-After` header share a single `RETRY_AFTER_SECS` constant
+- `ReadingBatServer.contentReadCount` is now `private`; readers use `isContentReady: Boolean` (interceptor + warning loop) and `contentLoadCount: Int` (admin diagnostics page); `markContentLoaded()` encapsulates the increment
+- Reverted the separate `healthRoutes` registration introduced in 3.1.6 — `/ping` is back inside `adminRoutes` because the new readiness gate makes the early registration unnecessary
+- Bumped version to 3.1.7
+
+### Removed
+
+- `Property.STARTUP_DELAY_SECS` and the matching `startupMaxDelaySecs` keys from `application-test.conf` and `application-travis.conf`
+
 ## [3.1.6] - 2026-05-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Reverted the separate `healthRoutes` registration introduced in 3.1.6 — `/ping` is back inside `adminRoutes` because the new readiness gate makes the early registration unnecessary
 - Bumped version to 3.1.7
 
+### Added
+
+- `ContentLoadingPageTest` covering the `RETRY_AFTER_SECS` constant, rendered HTML markers, and the by-lazy cache invariant
+- `ContentReadinessInterceptorTest` exercising the gate end-to-end: 503 + `Retry-After` + loading body for blocked paths, allowlisted `/ping` and `/static/*` pass-through, and post-`markContentLoaded()` request flow
+- `clean-all` Makefile target that runs `clean` + `clean-docs` and removes per-project `.gradle` caches
+
 ### Removed
 
 - `Property.STARTUP_DELAY_SECS` and the matching `startupMaxDelaySecs` keys from `application-test.conf` and `application-travis.conf`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := $(shell grep -E '^version=' gradle.properties | cut -d= -f2)
 
-.PHONY: default stop tw-css tw-full-css clean build scan uberjar uber run tests remote-tests \
+.PHONY: default stop tw-css tw-full-css clean clean-all build scan uberjar uber run tests remote-tests \
         coverage coverage-html coverage-verify \
         dbinfo dbclean dbmigrate dbreset dbvalidate lint depends versioncheck kdocs clean-docs \
         site publish-local publish-local-snapshot check-gpg-env publish-snapshot \
@@ -19,6 +19,9 @@ tw-full-css:
 
 clean:
 	./gradlew clean
+
+clean-all: clean clean-docs
+	rm -rf .gradle readingbat-core/.gradle readingbat-kotest/.gradle
 
 build: tw-css
 	./gradlew build -xtest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v3.1.7 — 2026-05-04
+
+Background DSL content loading and a readiness gate so platform health checks pass during cold starts.
+
+### Highlights
+
+- **Non-blocking startup.** `Application.module()` no longer waits for `readContentDsl(...)` before returning. The DSL load runs on `Dispatchers.IO`, so the Ktor engine starts serving immediately and `/ping` is reachable from the first second of the deploy. This fixes DigitalOcean (and similar platforms) timing out the deployment health check while GitHub-backed content is still being fetched and evaluated.
+- **Loading page.** A new `Plugins`-phase interceptor in `Intercepts.kt` returns `503 Service Unavailable` with `Retry-After: 5` and a cached `ContentLoadingPage` for any user-facing path until the first DSL load completes. The page meta-refreshes every 5 seconds, so browsers automatically pick up the site once content is ready. A small allowlist (`/ping`, `/static/*`, favicon, robots, ktor shutdown) stays available throughout startup.
+- **Heartbeat warnings.** A 10-second polling loop logs `Content not loaded after Ns` until the load finishes — useful for spotting deploys where the DSL evaluation has stalled or failed. Replaces the old one-shot `STARTUP_DELAY_SECS` warning.
+- **Encapsulated readiness flag.** `ReadingBatServer.contentReadCount` is now private; the interceptor uses `isContentReady: Boolean` and the admin diagnostics page uses `contentLoadCount: Int`. `Property.STARTUP_DELAY_SECS` and its `application-test.conf` / `application-travis.conf` entries are removed.
+- **Revert of the 3.1.6 health-route split.** `/ping` is folded back into `adminRoutes`; the new readiness gate makes the early `healthRoutes` registration unnecessary.
+
+**Full Changelog**: https://github.com/readingbat/readingbat-core/compare/3.1.6...3.1.7
+
+---
+
 ## v3.1.6 — 2026-05-03
 
 Health-check routing fix, build-script polish, and a Kover patch bump.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,8 @@ Background DSL content loading and a readiness gate so platform health checks pa
 - **Heartbeat warnings.** A 10-second polling loop logs `Content not loaded after Ns` until the load finishes — useful for spotting deploys where the DSL evaluation has stalled or failed. Replaces the old one-shot `STARTUP_DELAY_SECS` warning.
 - **Encapsulated readiness flag.** `ReadingBatServer.contentReadCount` is now private; the interceptor uses `isContentReady: Boolean` and the admin diagnostics page uses `contentLoadCount: Int`. `Property.STARTUP_DELAY_SECS` and its `application-test.conf` / `application-travis.conf` entries are removed.
 - **Revert of the 3.1.6 health-route split.** `/ping` is folded back into `adminRoutes`; the new readiness gate makes the early `healthRoutes` registration unnecessary.
+- **Test coverage.** New `ContentLoadingPageTest` pins down the rendered HTML and the lazy-cache invariant, and `ContentReadinessInterceptorTest` drives the gate end-to-end through Ktor `testApplication` (blocked path → 503 + loading page; allowlisted paths → 200; post-`markContentLoaded()` → handler reached).
+- **Makefile.** New `clean-all` target runs `clean` + `clean-docs` and wipes the per-project `.gradle` caches.
 
 **Full Changelog**: https://github.com/readingbat/readingbat-core/compare/3.1.6...3.1.7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.1.6
+version=3.1.7
 
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
@@ -205,9 +205,6 @@ sealed class Property(
       initFunc = { setPropertyFromConfig(it, "") },
     )
 
-  object STARTUP_DELAY_SECS :
-    Property(propertyValue = "$READINGBAT.$SITE.startupMaxDelaySecs")
-
   // These are defaults for env var values
   object REDIRECT_HOSTNAME :
     Property(propertyValue = "$READINGBAT.$SITE.redirectHostname")

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.pages
+
+import com.readingbat.pages.PageUtils.bodyTitle
+import com.readingbat.pages.PageUtils.headDefault
+import com.readingbat.pages.PageUtils.loadPingdomScript
+import kotlinx.html.body
+import kotlinx.html.h2
+import kotlinx.html.head
+import kotlinx.html.html
+import kotlinx.html.meta
+import kotlinx.html.p
+import kotlinx.html.stream.createHTML
+
+/**
+ * Generated while the DSL content is still loading at server startup. Includes a meta refresh so
+ * browsers retry automatically once the content is ready.
+ */
+internal object ContentLoadingPage {
+  fun contentLoadingPage() =
+    createHTML()
+      .html {
+        head {
+          meta {
+            httpEquiv = "refresh"
+            content = "5"
+          }
+          headDefault()
+        }
+        body {
+          bodyTitle()
+          h2 { +"Site is loading" }
+          p { +"Site content is loading. Please try again in a moment." }
+          loadPingdomScript()
+        }
+      }
+}

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
@@ -33,7 +33,8 @@ import kotlinx.html.stream.createHTML
  * browsers retry automatically once the content is ready.
  */
 internal object ContentLoadingPage {
-  fun contentLoadingPage() =
+  // Cached at first access so the per-request readiness intercept doesn't rebuild this static HTML.
+  private val rendered: String by lazy {
     createHTML()
       .html {
         head {
@@ -50,4 +51,7 @@ internal object ContentLoadingPage {
           loadPingdomScript()
         }
       }
+  }
+
+  fun contentLoadingPage(): String = rendered
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ContentLoadingPage.kt
@@ -33,6 +33,9 @@ import kotlinx.html.stream.createHTML
  * browsers retry automatically once the content is ready.
  */
 internal object ContentLoadingPage {
+  /** Suggested retry interval shown to clients (browser meta-refresh, HTTP `Retry-After`). */
+  const val RETRY_AFTER_SECS = 5
+
   // Cached at first access so the per-request readiness intercept doesn't rebuild this static HTML.
   private val rendered: String by lazy {
     createHTML()
@@ -40,7 +43,7 @@ internal object ContentLoadingPage {
         head {
           meta {
             httpEquiv = "refresh"
-            content = "5"
+            content = RETRY_AFTER_SECS.toString()
           }
           headDefault()
         }

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/SystemConfigurationPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/SystemConfigurationPage.kt
@@ -301,7 +301,7 @@ internal object SystemConfigurationPage {
                 }
                 tr {
                   td { +"Content read count:" }
-                  td { +ReadingBatServer.contentReadCount.load().toString() }
+                  td { +ReadingBatServer.contentLoadCount.toString() }
                 }
               }
             }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
@@ -38,16 +38,22 @@ import com.readingbat.common.browserSession
 import com.readingbat.common.userPrincipal
 import com.readingbat.dsl.isDbmsEnabled
 import com.readingbat.dsl.isSaveRequestsEnabled
+import com.readingbat.pages.ContentLoadingPage.contentLoadingPage
 import com.readingbat.server.GeoInfo.Companion.lookupGeoInfo
 import com.readingbat.server.GeoInfo.Companion.queryGeoInfo
 import com.readingbat.server.Intercepts.clock
 import com.readingbat.server.Intercepts.logger
 import com.readingbat.server.Intercepts.publicPaths
 import com.readingbat.server.Intercepts.publicPrefixes
+import com.readingbat.server.Intercepts.readinessAllowedPaths
+import com.readingbat.server.Intercepts.readinessAllowedPrefixes
 import com.readingbat.server.Intercepts.requestTimingMap
 import com.readingbat.server.ServerUtils.fetchUserDbmsIdFromCache
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpHeaders.UserAgent
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Plugins
@@ -63,7 +69,9 @@ import io.ktor.server.plugins.origin
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.request.queryString
+import io.ktor.server.response.header
 import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingRoot.Plugin.RoutingCallFinished
 import io.ktor.server.routing.RoutingRoot.Plugin.RoutingCallStarted
 import io.ktor.server.sessions.sessions
@@ -118,6 +126,22 @@ internal object Intercepts {
     "/static/",
   )
 
+  // Paths that must remain available before the DSL content has finished loading.
+  // Anything else gets a 503 + ContentLoadingPage until ReadingBatServer.isContentReady is true.
+  val readinessAllowedPaths =
+    setOf(
+      PING_ENDPOINT,
+      "/favicon.ico",
+      "/robots.txt",
+      "/ktor/application/shutdown",
+    )
+
+  val readinessAllowedPrefixes =
+    listOf(
+      "/$STATIC/",
+      "/static/",
+    )
+
   @Suppress("unused")
   val timer =
     timer("requestTimingMap admin", false, 1.minutes.inWholeMilliseconds, 1.minutes.inWholeMilliseconds) {
@@ -156,6 +180,21 @@ internal fun Application.intercepts() {
 
   intercept(ApplicationCallPipeline.Monitoring) {
     // Phase for tracing calls, useful for logging, metrics, error handling and so on
+  }
+
+  // Short-circuit user-facing requests with a "site loading" page until the DSL content has
+  // finished loading at least once. Health, static assets, and a few other path-independent
+  // endpoints stay available so platform health checks pass during startup.
+  intercept(Plugins) {
+    if (!ReadingBatServer.isContentReady) {
+      val path = call.request.path()
+      val isAllowed = path in readinessAllowedPaths || readinessAllowedPrefixes.any { path.startsWith(it) }
+      if (!isAllowed) {
+        call.response.header(HttpHeaders.RetryAfter, "5")
+        call.respondText(contentLoadingPage(), ContentType.Text.Html, HttpStatusCode.ServiceUnavailable)
+        finish()
+      }
+    }
   }
 
   // Mandatory auth: redirect unauthenticated users to homepage

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
@@ -23,6 +23,7 @@ import com.readingbat.common.Constants.STATIC
 import com.readingbat.common.Constants.UNKNOWN_USER_ID
 import com.readingbat.common.Endpoints.ABOUT_ENDPOINT
 import com.readingbat.common.Endpoints.CHALLENGE_ROOT
+import com.readingbat.common.Endpoints.FAV_ICON_ENDPOINT
 import com.readingbat.common.Endpoints.HELP_ENDPOINT
 import com.readingbat.common.Endpoints.OAUTH_CALLBACK_GITHUB_ENDPOINT
 import com.readingbat.common.Endpoints.OAUTH_CALLBACK_GOOGLE_ENDPOINT
@@ -30,6 +31,7 @@ import com.readingbat.common.Endpoints.OAUTH_LOGIN_GITHUB_ENDPOINT
 import com.readingbat.common.Endpoints.OAUTH_LOGIN_GOOGLE_ENDPOINT
 import com.readingbat.common.Endpoints.PING_ENDPOINT
 import com.readingbat.common.Endpoints.PRIVACY_POLICY_ENDPOINT
+import com.readingbat.common.Endpoints.ROBOTS_ENDPOINT
 import com.readingbat.common.Endpoints.ROOT
 import com.readingbat.common.Endpoints.TOS_ENDPOINT
 import com.readingbat.common.OAuthReturnUrl
@@ -131,8 +133,8 @@ internal object Intercepts {
   val readinessAllowedPaths =
     setOf(
       PING_ENDPOINT,
-      "/favicon.ico",
-      "/robots.txt",
+      FAV_ICON_ENDPOINT,
+      ROBOTS_ENDPOINT,
       "/ktor/application/shutdown",
     )
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
@@ -40,6 +40,7 @@ import com.readingbat.common.browserSession
 import com.readingbat.common.userPrincipal
 import com.readingbat.dsl.isDbmsEnabled
 import com.readingbat.dsl.isSaveRequestsEnabled
+import com.readingbat.pages.ContentLoadingPage
 import com.readingbat.pages.ContentLoadingPage.contentLoadingPage
 import com.readingbat.server.GeoInfo.Companion.lookupGeoInfo
 import com.readingbat.server.GeoInfo.Companion.queryGeoInfo
@@ -192,7 +193,7 @@ internal fun Application.intercepts() {
       val path = call.request.path()
       val isAllowed = path in readinessAllowedPaths || readinessAllowedPrefixes.any { path.startsWith(it) }
       if (!isAllowed) {
-        call.response.header(HttpHeaders.RetryAfter, "5")
+        call.response.header(HttpHeaders.RetryAfter, ContentLoadingPage.RETRY_AFTER_SECS.toString())
         call.respondText(contentLoadingPage(), ContentType.Text.Html, HttpStatusCode.ServiceUnavailable)
         finish()
       }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
@@ -49,8 +49,9 @@ import com.readingbat.server.Locations.locations
 import com.readingbat.server.ReadingBatServer.adminUsersRef
 import com.readingbat.server.ReadingBatServer.assignKotlinScriptProperty
 import com.readingbat.server.ReadingBatServer.content
-import com.readingbat.server.ReadingBatServer.contentReadCount
+import com.readingbat.server.ReadingBatServer.isContentReady
 import com.readingbat.server.ReadingBatServer.logger
+import com.readingbat.server.ReadingBatServer.markContentLoaded
 import com.readingbat.server.ReadingBatServer.metrics
 import com.readingbat.server.ReadingBatServer.start
 import com.readingbat.server.ServerUtils.logToShim
@@ -69,9 +70,9 @@ import io.ktor.server.engine.CommandLineConfig
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.routing.routing
 import io.prometheus.Agent.Companion.startAsyncAgent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.exposed.v1.jdbc.Database
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -106,7 +107,18 @@ object ReadingBatServer {
   internal var callerVersion = ""
   internal val content = AtomicReference(ReadingBatContent())
   internal val adminUsersRef = AtomicReference<Set<String>>(emptySet())
-  internal val contentReadCount = AtomicInt(0)
+  private val contentReadCount = AtomicInt(0)
+
+  /** True once the DSL content has been successfully loaded at least once. */
+  internal val isContentReady: Boolean get() = contentReadCount.load() > 0
+
+  /** Cumulative number of times the DSL content has been (re)loaded; used for the admin diagnostics page. */
+  internal val contentLoadCount: Int get() = contentReadCount.load()
+
+  /** Records that a DSL content load has just completed successfully. */
+  internal fun markContentLoaded() {
+    contentReadCount += 1
+  }
 
   /** Lazily initialized database connection using HikariCP connection pooling. */
   internal val dbms by lazy {
@@ -214,7 +226,7 @@ object ReadingBatServer {
 
 /**
  * Loads and evaluates the content DSL from [fileName], extracting the [ReadingBatContent]
- * instance bound to [variableName]. Increments [contentReadCount] and publishes metrics
+ * instance bound to [variableName]. Calls [markContentLoaded] and publishes metrics
  * on each successful load.
  */
 internal fun Application.readContentDsl(fileName: String, variableName: String, logId: String = "") {
@@ -243,7 +255,7 @@ internal fun Application.readContentDsl(fileName: String, variableName: String, 
       }
   }
 
-  contentReadCount += 1
+  markContentLoaded()
 }
 
 /**
@@ -286,18 +298,19 @@ fun Application.module() {
   val dslFileName = Property.DSL_FILE_NAME.getRequiredProperty()
   val dslVariableName = Property.DSL_VARIABLE_NAME.getRequiredProperty()
 
-  val job = launch { readContentDsl(dslFileName, dslVariableName) }
+  // Load content in the background so the Ktor module returns immediately and the platform
+  // health check (e.g. /ping) becomes available right away. The readiness interceptor in
+  // Intercepts.kt serves a "loading" page on user-facing routes until isContentReady is true.
+  // Use Dispatchers.IO so the (blocking) DSL read + script eval cannot be starved by — or
+  // starve — request-handling threads on the default dispatcher.
+  launch(Dispatchers.IO) { readContentDsl(dslFileName, dslVariableName) }
 
-  runBlocking {
-    val maxDelay = Property.STARTUP_DELAY_SECS.configValue(this@module, "60").toInt().seconds
-    logger.info { "Delaying start-up by max of $maxDelay" }
-    measureTime {
-      withTimeoutOrNull(maxDelay) {
-        job.join()
-      } ?: logger.error { "Timed-out after waiting $maxDelay" }
-    }.also {
-      logger.info { "Continued start-up after delaying $it" }
-    }
+  // Warn (do not block) if the content load is still pending after STARTUP_DELAY_SECS.
+  launch {
+    val maxDelay = Property.STARTUP_DELAY_SECS.configValue(this@module, "10").toInt().seconds
+    delay(maxDelay)
+    if (!isContentReady)
+      logger.warn { "Content still not loaded after $maxDelay" }
   }
 
   // readContentDsl() is passed as a lambda because it is Application.readContentDsl()

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
@@ -55,7 +55,6 @@ import com.readingbat.server.ReadingBatServer.metrics
 import com.readingbat.server.ReadingBatServer.start
 import com.readingbat.server.ServerUtils.logToShim
 import com.readingbat.server.routes.AdminRoutes.adminRoutes
-import com.readingbat.server.routes.AdminRoutes.healthRoutes
 import com.readingbat.server.routes.oauthRoutes
 import com.readingbat.server.routes.sysAdminRoutes
 import com.readingbat.server.routes.userRoutes
@@ -286,11 +285,6 @@ fun Application.module() {
 
   val dslFileName = Property.DSL_FILE_NAME.getRequiredProperty()
   val dslVariableName = Property.DSL_VARIABLE_NAME.getRequiredProperty()
-
-  // Initialize this early so that we do not fail the health check while loading the GitHub content
-  routing {
-    healthRoutes(metrics)
-  }
 
   val job = launch { readContentDsl(dslFileName, dslVariableName) }
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ReadingBatServer.kt
@@ -248,7 +248,7 @@ internal fun Application.readContentDsl(fileName: String, variableName: String, 
     )
     metrics.contentLoadedCount.labels(agentLaunchId()).inc()
   }.also { dur ->
-    "Loaded content using $variableName in $fileName in $dur"
+    "Loaded content using $variableName in $fileName in ${dur.inWholeSeconds}s"
       .also {
         logger.info { it }
         logToShim(it, logId)
@@ -305,12 +305,15 @@ fun Application.module() {
   // starve — request-handling threads on the default dispatcher.
   launch(Dispatchers.IO) { readContentDsl(dslFileName, dslVariableName) }
 
-  // Warn (do not block) if the content load is still pending after STARTUP_DELAY_SECS.
+  // Poll every 10 seconds and keep warning until the content has finished loading.
   launch {
-    val maxDelay = Property.STARTUP_DELAY_SECS.configValue(this@module, "10").toInt().seconds
-    delay(maxDelay)
-    if (!isContentReady)
-      logger.warn { "Content still not loaded after $maxDelay" }
+    val pollInterval = 10.seconds
+    val start = TimeSource.Monotonic.markNow()
+    while (true) {
+      delay(pollInterval)
+      if (isContentReady) break
+      logger.warn { "Content not loaded after ${start.elapsedNow().inWholeSeconds}s" }
+    }
   }
 
   // readContentDsl() is passed as a lambda because it is Application.readContentDsl()

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/AdminRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/AdminRoutes.kt
@@ -80,13 +80,11 @@ object AdminRoutes {
     return true
   }
 
-  fun Routing.healthRoutes(metrics: Metrics) {
+  fun Routing.adminRoutes(metrics: Metrics) {
     get(PING_ENDPOINT, metrics) {
       call.respondText("pong", Plain)
     }
-  }
 
-  fun Routing.adminRoutes(metrics: Metrics) {
     get(THREAD_DUMP, metrics) {
       if (!requireAdminUser()) return@get
 

--- a/readingbat-core/src/test/kotlin/com/readingbat/pages/ContentLoadingPageTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/pages/ContentLoadingPageTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.pages
+
+import com.readingbat.kotest.TestSupport.initTestProperties
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class ContentLoadingPageTest : StringSpec() {
+  init {
+    "RETRY_AFTER_SECS is the single source for the meta-refresh and the Retry-After header" {
+      ContentLoadingPage.RETRY_AFTER_SECS shouldBe 5
+    }
+
+    "rendered HTML contains the meta-refresh tag and the loading message" {
+      initTestProperties()
+      val html = ContentLoadingPage.contentLoadingPage()
+      html shouldContain """http-equiv="refresh""""
+      html shouldContain """content="${ContentLoadingPage.RETRY_AFTER_SECS}""""
+      html shouldContain "Site is loading"
+    }
+
+    "repeated calls return the cached instance" {
+      initTestProperties()
+      val a = ContentLoadingPage.contentLoadingPage()
+      val b = ContentLoadingPage.contentLoadingPage()
+      a shouldBeSameInstanceAs b
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ContentReadinessInterceptorTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ContentReadinessInterceptorTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server
+
+import com.readingbat.common.Endpoints.PING_ENDPOINT
+import com.readingbat.common.Property
+import com.readingbat.kotest.TestSupport.initTestProperties
+import com.readingbat.pages.ContentLoadingPage
+import com.readingbat.server.ReadingBatServer.isContentReady
+import com.readingbat.server.ReadingBatServer.markContentLoaded
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+
+/**
+ * Exercises the readiness interceptor registered by [intercepts]: while the DSL content has not
+ * yet been loaded, user-facing paths return [HttpStatusCode.ServiceUnavailable] with the
+ * [ContentLoadingPage] body and a `Retry-After` header; allowlisted paths (ping, static) pass
+ * through; once [markContentLoaded] is called, the gate flips and previously-blocked paths
+ * reach their handlers.
+ *
+ * Note: this test mutates [ReadingBatServer.contentReadCount] (a JVM-global `AtomicInt`) and
+ * leaves it incremented. No other tests currently consume `isContentReady`, so this is safe;
+ * any future test that does will need to account for the JVM-shared state.
+ */
+class ContentReadinessInterceptorTest : StringSpec() {
+  init {
+    "readiness interceptor blocks user paths until content is marked loaded" {
+      initTestProperties()
+      // Disable DBMS so the existing auth intercept (which depends on Ktor Sessions / DB lookups)
+      // does not fire — this test stays focused on the readiness gate. Earlier tests in the same
+      // JVM may have flipped this property on, so set it explicitly here.
+      Property.DBMS_ENABLED.setProperty("false")
+      isContentReady shouldBe false
+
+      testApplication {
+        application {
+          intercepts()
+          routing {
+            get("/anything") { call.respondText("would-not-be-served") }
+            get(PING_ENDPOINT) { call.respondText("pong") }
+            get("/static/foo.css") { call.respondText("body { }", ContentType.Text.CSS) }
+          }
+        }
+
+        client.get("/anything").also {
+          it.status shouldBe HttpStatusCode.ServiceUnavailable
+          it.headers[HttpHeaders.RetryAfter] shouldBe ContentLoadingPage.RETRY_AFTER_SECS.toString()
+          it.bodyAsText() shouldContain "Site is loading"
+        }
+        client.get(PING_ENDPOINT).status shouldBe HttpStatusCode.OK
+        client.get("/static/foo.css").status shouldBe HttpStatusCode.OK
+
+        markContentLoaded()
+        isContentReady shouldBe true
+
+        client.get("/anything").also {
+          it.status shouldBe HttpStatusCode.OK
+          it.bodyAsText() shouldBe "would-not-be-served"
+        }
+      }
+    }
+  }
+}

--- a/readingbat-core/src/test/resources/application-test.conf
+++ b/readingbat-core/src/test/resources/application-test.conf
@@ -15,7 +15,6 @@ readingbat {
     pingdomBannerId = "f109764d"
     pingdomUrl = "//rum-static.pingdom.net/pa-5f5a96ac146aea0015000ae4.js"
     statusPageUrl = "https://0cclkstp9fd6.statuspage.io/embed/script.js"
-    startupMaxDelaySecs = 30
     forwardedHeaderSupportEnabled = false
     xforwardedHeaderSupportEnabled = false
     oauthCallbackUrlPrefix = "http://localhost:8080"

--- a/readingbat-core/src/test/resources/application-travis.conf
+++ b/readingbat-core/src/test/resources/application-travis.conf
@@ -15,7 +15,6 @@ readingbat {
     pingdomBannerId = "f109764d"
     pingdomUrl = "//rum-static.pingdom.net/pa-5f5a96ac146aea0015000ae4.js"
     statusPageUrl = "https://0cclkstp9fd6.statuspage.io/embed/script.js"
-    startupMaxDelaySecs = 30
     forwardedHeaderSupportEnabled = false
     xforwardedHeaderSupportEnabled = false
   }

--- a/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
+++ b/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
@@ -37,7 +37,6 @@ import com.readingbat.server.Installs.installs
 import com.readingbat.server.Locations.locations
 import com.readingbat.server.ReadingBatServer
 import com.readingbat.server.routes.AdminRoutes.adminRoutes
-import com.readingbat.server.routes.AdminRoutes.healthRoutes
 import com.readingbat.server.routes.sysAdminRoutes
 import com.readingbat.server.routes.userRoutes
 import com.readingbat.server.ws.WsCommon.wsRoutes
@@ -194,7 +193,6 @@ object TestSupport {
     installs(production)
 
     routing {
-      healthRoutes(ReadingBatServer.metrics)
       adminRoutes(ReadingBatServer.metrics)
       locations(ReadingBatServer.metrics) { content }
       userRoutes(ReadingBatServer.metrics) { content }


### PR DESCRIPTION
## Summary

- `Application.module()` no longer blocks on `readContentDsl`. The load runs on `Dispatchers.IO`, so the Ktor engine starts serving immediately and the DigitalOcean platform health check (`/ping`) is reachable during deploy.
- A new `Plugins`-phase interceptor in `Intercepts.kt` returns `503 Service Unavailable` + `Retry-After: 5` and a cached `ContentLoadingPage` for any path not in a tiny readiness allowlist (`/ping`, `/static/*`, favicon, robots, ktor shutdown). The browser meta-refreshes every 5s; once the first DSL load completes, the gate flips on permanently.
- A 10s polling loop logs `Content not loaded after Ns` until the load finishes, replacing the old one-shot `STARTUP_DELAY_SECS` warning. `Property.STARTUP_DELAY_SECS` and the matching `application-test.conf` / `application-travis.conf` entries are removed.
- `ReadingBatServer.contentReadCount` is now `private`; readers use `isContentReady: Boolean` (interceptor + warning loop) and `contentLoadCount: Int` (admin diagnostics page). `markContentLoaded()` encapsulates the increment.
- The `ContentLoadingPage` HTML is built once via a `by lazy` cache, and the `Retry-After` header / meta-refresh share a single `RETRY_AFTER_SECS` constant.
- Reverts the separate `healthRoutes` registration introduced in 3.1.6 — the ping endpoint moves back into `adminRoutes` since the new readiness gate makes the early registration unnecessary.

## Test plan

- [ ] `./gradlew check` (already passing locally)
- [ ] `make run` then within the first second: `curl -i /ping` → 200; `curl -i /` → 503 with loading-page HTML and `Retry-After: 5`; `curl -i /static/tailwind.css` → 200
- [ ] After the `Loaded content using ...` log line: `/` redirects to default language tab; `/content/java` serves the languageGroup page
- [ ] Confirm DigitalOcean deploy health check succeeds during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)