### PR TITLE
Return 200 from readiness gate so DO serves the loading page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to ReadingBat Core are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.1.8] - 2026-05-04
+
+### Changed
+
+- Readiness interceptor now responds with `200 OK` instead of `503 Service Unavailable` so DigitalOcean's edge router does not substitute its own error body for the `ContentLoadingPage`. The page's meta-refresh and the `Retry-After` header still drive client retries
+- Added `Cache-Control: no-store` to the loading-page response so proxies and browsers don't cache it past the loading window
+- `ContentReadinessInterceptorTest` updated to assert the new `200` status and `Cache-Control` header
+- Documented the recommended DigitalOcean App Platform health-check path (`/ping`) in `docs/digitalocean-notes.txt`
+- Bumped version to 3.1.8
+
 ## [3.1.7] - 2026-05-04
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v3.1.8 — 2026-05-04
+
+Hot-fix for DigitalOcean App Platform deploys: the 3.1.7 readiness gate returned `503` for user-facing paths during the loading window, but DO's edge router substitutes its own body for upstream 5xx responses, so the `ContentLoadingPage` HTML never reached the browser.
+
+### Highlights
+
+- **Readiness response is now `200 OK`.** The loading-page response status flips from `503 Service Unavailable` to `200 OK`. The page's `meta http-equiv="refresh"` and the `Retry-After: 5` header still drive automatic client retries, but DO no longer treats the response as a failed upstream and substitutes its own page.
+- **`Cache-Control: no-store` on the loading page.** Prevents intermediate proxies and browser caches from serving the loading page after content is ready.
+- **Health-check guidance.** `docs/digitalocean-notes.txt` now documents pointing the App Platform HTTP health check at `/ping` so the instance stays healthy through cold starts.
+
+**Full Changelog**: https://github.com/readingbat/readingbat-core/compare/3.1.7...3.1.8
+
+---
+
 ## v3.1.7 — 2026-05-04
 
 Background DSL content loading and a readiness gate so platform health checks pass during cold starts.

--- a/docs/digitalocean-notes.txt
+++ b/docs/digitalocean-notes.txt
@@ -2,3 +2,27 @@ To determine the IP address of your local machine for whitelisting, use:
  curl ifconfig.me
 
 URL: jdbc:postgresql://name.ondigitalocean.com:45060/readingbat?sslmode=require
+
+App Platform health check
+=========================
+Point the service's HTTP health check at /ping (not /). The /ping endpoint
+is in the readiness allowlist and returns 200 immediately, so the instance
+stays "healthy" while the DSL content is still loading in the background.
+If the health check probes / (or any user-facing path), the readiness
+interceptor returns the loading page during cold starts and DO will mark
+the instance unhealthy.
+
+Recommended .do/app.yaml health_check stanza:
+
+  services:
+    - name: readingbat
+      health_check:
+        http_path: /ping
+        initial_delay_seconds: 5
+        period_seconds: 10
+        timeout_seconds: 3
+        success_threshold: 1
+        failure_threshold: 5
+
+Or set the same values under Settings -> Components -> <service> ->
+Health Checks in the App Platform dashboard.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=3.1.7
+version=3.1.8
 
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Intercepts.kt
@@ -193,8 +193,13 @@ internal fun Application.intercepts() {
       val path = call.request.path()
       val isAllowed = path in readinessAllowedPaths || readinessAllowedPrefixes.any { path.startsWith(it) }
       if (!isAllowed) {
+        // Respond 200 (not 503): the DigitalOcean edge router substitutes its own body for upstream
+        // 5xx responses, so a 503 loading page never reaches the user. The page's meta-refresh and
+        // the Retry-After header still drive client retries.
         call.response.header(HttpHeaders.RetryAfter, ContentLoadingPage.RETRY_AFTER_SECS.toString())
-        call.respondText(contentLoadingPage(), ContentType.Text.Html, HttpStatusCode.ServiceUnavailable)
+        // Prevent proxies/browsers from caching the loading page past the brief loading window.
+        call.response.header(HttpHeaders.CacheControl, "no-store")
+        call.respondText(contentLoadingPage(), ContentType.Text.Html, HttpStatusCode.OK)
         finish()
       }
     }

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ContentReadinessInterceptorTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ContentReadinessInterceptorTest.kt
@@ -39,10 +39,10 @@ import io.ktor.server.testing.testApplication
 
 /**
  * Exercises the readiness interceptor registered by [intercepts]: while the DSL content has not
- * yet been loaded, user-facing paths return [HttpStatusCode.ServiceUnavailable] with the
- * [ContentLoadingPage] body and a `Retry-After` header; allowlisted paths (ping, static) pass
- * through; once [markContentLoaded] is called, the gate flips and previously-blocked paths
- * reach their handlers.
+ * yet been loaded, user-facing paths return the [ContentLoadingPage] body with a `Retry-After`
+ * header and `Cache-Control: no-store` (status `200 OK` so platform edge routers don't substitute
+ * their own error body); allowlisted paths (ping, static) pass through to their handlers; once
+ * [markContentLoaded] is called, the gate flips and previously-blocked paths reach their handlers.
  *
  * Note: this test mutates [ReadingBatServer.contentReadCount] (a JVM-global `AtomicInt`) and
  * leaves it incremented. No other tests currently consume `isContentReady`, so this is safe;
@@ -69,8 +69,9 @@ class ContentReadinessInterceptorTest : StringSpec() {
         }
 
         client.get("/anything").also {
-          it.status shouldBe HttpStatusCode.ServiceUnavailable
+          it.status shouldBe HttpStatusCode.OK
           it.headers[HttpHeaders.RetryAfter] shouldBe ContentLoadingPage.RETRY_AFTER_SECS.toString()
+          it.headers[HttpHeaders.CacheControl] shouldBe "no-store"
           it.bodyAsText() shouldContain "Site is loading"
         }
         client.get(PING_ENDPOINT).status shouldBe HttpStatusCode.OK


### PR DESCRIPTION
## Summary

- Hot-fix for 3.1.7 deploys on DigitalOcean App Platform: DO's edge router substitutes its own body for any upstream 5xx, so the `503` `ContentLoadingPage` introduced last release never reached browsers — users saw a generic "503 Service Unavailable" instead of our loading page.
- Readiness interceptor now responds `200 OK` (was `503 Service Unavailable`). The page's `meta http-equiv="refresh"` and the `Retry-After: 5` header still drive automatic client retries; DO no longer treats the response as a failed upstream.
- Adds `Cache-Control: no-store` to the loading-page response so proxies and browsers don't cache it past the loading window.
- `ContentReadinessInterceptorTest` updated for the new status + header.
- Documents the recommended `/ping` health-check path for DO App Platform in `docs/digitalocean-notes.txt`.
- Version bump `3.1.7` → `3.1.8`; CHANGELOG and RELEASE_NOTES updated.

## Test plan

- [ ] `./gradlew check` (passes locally)
- [ ] Redeploy to DigitalOcean: during the loading window the browser sees the `ContentLoadingPage` HTML (auto-refreshes every 5s) instead of DO's generic error page
- [ ] After content loads, normal pages resolve as before
- [ ] Confirm `Retry-After: 5` and `Cache-Control: no-store` are present on the loading-page response (`curl -i /` during cold start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)