### PR TITLE
Convert upsert() calls to Exposed's native upsert()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 .PHONY: default help stop tw-css tw-full-css clean clean-all build scan uberjar uber run tests remote-tests \
         coverage coverage-html coverage-xml coverage-log coverage-verify coverage-open coverage-packages coverage-clean \
         dbinfo dbclean dbmigrate dbvalidate lint detekt detekt-baseline depends versions kdocs clean-docs \
-        site publish-local publish-local-snapshot publish-snapshot \
-        publish-maven-central upgrade-wrapper \
+        site publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper \
         _check-gpg-env _require-version _require-gradle-version
 
 VERSION := $(shell sed -n 's/^version=\(.*\)/\1/p' gradle.properties)

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
@@ -228,8 +228,8 @@ class User {
         select(likeDislike)
           .where {
             (userRef eq userDbmsId) and
-            ((likeDislike eq LikeDislike.LIKE.value) or (likeDislike eq LikeDislike.DISLIKE.value))
-              }
+              ((likeDislike eq LikeDislike.LIKE.value) or (likeDislike eq LikeDislike.DISLIKE.value))
+          }
           .map { it.toString() }
       }
     }
@@ -359,7 +359,7 @@ class User {
   fun assignActiveClassCode(classCode: ClassCode, resetPreviousClassCode: Boolean) =
     transaction {
       with(UserSessionsTable) {
-        upsert(userSessionIndex) { row ->
+        upsert(conflictIndex = userSessionIndex) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -374,7 +374,7 @@ class User {
     logger.info { "Resetting $fullName ($email) active class code" }
     transaction {
       with(UserSessionsTable) {
-        upsert(userSessionIndex) { row ->
+        upsert(conflictIndex = userSessionIndex) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -475,29 +475,29 @@ class User {
     readonlyTx {
       val browserSessionCount =
         with(UserSessionsTable) {
-        select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
-      }
+          select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
+        }
       val correctAnswerCount =
         with(UserChallengeInfoTable) {
-        select(Count(id)).where { (userRef eq userDbmsId) and allCorrect }.map { it[0] as Long }.first()
-      }
+          select(Count(id)).where { (userRef eq userDbmsId) and allCorrect }.map { it[0] as Long }.first()
+        }
       val likeDislikeCount =
         with(UserChallengeInfoTable) {
-        select(Count(id))
-          .where {
-            (userRef eq userDbmsId) and
-            ((likeDislike eq LikeDislike.LIKE.value) or (likeDislike eq LikeDislike.DISLIKE.value))
-              }
-          .map { it[0] as Long }.first()
-      }
+          select(Count(id))
+            .where {
+              (userRef eq userDbmsId) and
+                ((likeDislike eq LikeDislike.LIKE.value) or (likeDislike eq LikeDislike.DISLIKE.value))
+            }
+            .map { it[0] as Long }.first()
+        }
       val challengeCount =
         with(UserChallengeInfoTable) {
-        select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
-      }
+          select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
+        }
       val invocationCount =
         with(UserAnswerHistoryTable) {
-        select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
-      }
+          select(Count(id)).where { userRef eq userDbmsId }.map { it[0] as Long }.first()
+        }
 
       logger.info { "Deleting User: $userId $fullName ($email)" }
       logger.info { "Browser sessions: $browserSessionCount, Correct: $correctAnswerCount, Likes: $likeDislikeCount" }
@@ -527,7 +527,7 @@ class User {
         val history = ChallengeHistory(result.invocation).apply { markUnanswered() }
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = userDbmsId
               row[md5] = challenge.md5(result.invocation)
               row[updated] = nowInstant()
@@ -594,13 +594,13 @@ class User {
 
         else -> {
           transaction {
-          with(UserSessionsTable) {
-            select(column)
-              .where { (sessionRef eq user.queryOrCreateSessionDbmsId()) and (userRef eq user.userDbmsId) }
-              .map { it[0] as String }
-              .firstOrNull()?.let { ClassCode(it) } ?: DISABLED_CLASS_CODE
+            with(UserSessionsTable) {
+              select(column)
+                .where { (sessionRef eq user.queryOrCreateSessionDbmsId()) and (userRef eq user.userDbmsId) }
+                .map { it[0] as String }
+                .firstOrNull()?.let { ClassCode(it) } ?: DISABLED_CLASS_CODE
+            }
           }
-        }
         }
       }
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
@@ -22,7 +22,6 @@ import com.pambrose.common.email.Email.Companion.EMPTY_EMAIL
 import com.pambrose.common.email.Email.Companion.UNKNOWN_EMAIL
 import com.pambrose.common.exposed.get
 import com.pambrose.common.exposed.readonlyTx
-import com.pambrose.common.exposed.upsert
 import com.pambrose.common.util.maxLength
 import com.pambrose.common.util.md5Of
 import com.pambrose.common.util.randomId
@@ -82,6 +81,7 @@ import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import org.jetbrains.exposed.v1.jdbc.upsert
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.contracts.contract
 import kotlin.time.measureTime
@@ -359,7 +359,7 @@ class User {
   fun assignActiveClassCode(classCode: ClassCode, resetPreviousClassCode: Boolean) =
     transaction {
       with(UserSessionsTable) {
-        upsert(conflictIndex = userSessionIndex) { row ->
+        upsert(*userSessionIndex.columns.toTypedArray()) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -374,7 +374,7 @@ class User {
     logger.info { "Resetting $fullName ($email) active class code" }
     transaction {
       with(UserSessionsTable) {
-        upsert(conflictIndex = userSessionIndex) { row ->
+        upsert(*userSessionIndex.columns.toTypedArray()) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -527,7 +527,7 @@ class User {
         val history = ChallengeHistory(result.invocation).apply { markUnanswered() }
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = userDbmsId
               row[md5] = challenge.md5(result.invocation)
               row[updated] = nowInstant()

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
@@ -62,6 +62,7 @@ import com.readingbat.server.UserAnswerHistoryTable
 import com.readingbat.server.UserChallengeInfoTable
 import com.readingbat.server.UserSessionsTable
 import com.readingbat.server.UsersTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userAnswerHistoryIndex
 import com.readingbat.server.userSessionIndex
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -81,7 +82,6 @@ import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
-import org.jetbrains.exposed.v1.jdbc.upsert
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.contracts.contract
 import kotlin.time.measureTime
@@ -359,7 +359,7 @@ class User {
   fun assignActiveClassCode(classCode: ClassCode, resetPreviousClassCode: Boolean) =
     transaction {
       with(UserSessionsTable) {
-        upsert(*userSessionIndex.columns.toTypedArray()) { row ->
+        upsert(userSessionIndex) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -374,7 +374,7 @@ class User {
     logger.info { "Resetting $fullName ($email) active class code" }
     transaction {
       with(UserSessionsTable) {
-        upsert(*userSessionIndex.columns.toTypedArray()) { row ->
+        upsert(userSessionIndex) { row ->
           row[sessionRef] = queryOrCreateSessionDbmsId()
           row[userRef] = userDbmsId
           row[updated] = nowInstant()
@@ -527,7 +527,7 @@ class User {
         val history = ChallengeHistory(result.invocation).apply { markUnanswered() }
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = userDbmsId
               row[md5] = challenge.md5(result.invocation)
               row[updated] = nowInstant()

--- a/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
@@ -17,7 +17,6 @@
 
 package com.readingbat.posts
 
-import com.pambrose.common.exposed.upsert
 import com.pambrose.common.util.encode
 import com.pambrose.common.util.maxLength
 import com.pambrose.common.util.md5Of
@@ -83,6 +82,7 @@ import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 internal data class StudentInfo(val studentId: String, val firstName: String, val lastName: String)
 
@@ -411,7 +411,7 @@ internal object ChallengePost {
               }
 
             with(UserChallengeInfoTable) {
-              upsert(conflictIndex = userChallengeInfoIndex) { row ->
+              upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
                 row[userRef] = user.userDbmsId
                 row[md5] = challengeMd5
                 row[updated] = nowInstant()
@@ -423,7 +423,7 @@ internal object ChallengePost {
             // Save the history of each answer on a per-invocation basis
             pairs.forEach { (historyMd5, history) ->
               with(UserAnswerHistoryTable) {
-                upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+                upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
                   row[userRef] = user.userDbmsId
                   row[md5] = historyMd5
                   row[invocation] = history.invocation.value
@@ -457,7 +457,7 @@ internal object ChallengePost {
       val challengeMd5 = names.md5()
       transaction {
         with(UserChallengeInfoTable) {
-          upsert(conflictIndex = userChallengeInfoIndex) { row ->
+          upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
             row[userRef] = user.userDbmsId
             row[md5] = challengeMd5
             row[updated] = nowInstant()

--- a/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
@@ -411,7 +411,7 @@ internal object ChallengePost {
               }
 
             with(UserChallengeInfoTable) {
-              upsert(userChallengeInfoIndex) { row ->
+              upsert(conflictIndex = userChallengeInfoIndex) { row ->
                 row[userRef] = user.userDbmsId
                 row[md5] = challengeMd5
                 row[updated] = nowInstant()
@@ -423,7 +423,7 @@ internal object ChallengePost {
             // Save the history of each answer on a per-invocation basis
             pairs.forEach { (historyMd5, history) ->
               with(UserAnswerHistoryTable) {
-                upsert(userAnswerHistoryIndex) { row ->
+                upsert(conflictIndex = userAnswerHistoryIndex) { row ->
                   row[userRef] = user.userDbmsId
                   row[md5] = historyMd5
                   row[invocation] = history.invocation.value
@@ -457,7 +457,7 @@ internal object ChallengePost {
       val challengeMd5 = names.md5()
       transaction {
         with(UserChallengeInfoTable) {
-          upsert(userChallengeInfoIndex) { row ->
+          upsert(conflictIndex = userChallengeInfoIndex) { row ->
             row[userRef] = user.userDbmsId
             row[md5] = challengeMd5
             row[updated] = nowInstant()

--- a/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
@@ -62,6 +62,7 @@ import com.readingbat.server.PageResult
 import com.readingbat.server.ServerUtils.paramMap
 import com.readingbat.server.UserAnswerHistoryTable
 import com.readingbat.server.UserChallengeInfoTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userAnswerHistoryIndex
 import com.readingbat.server.userChallengeInfoIndex
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -82,7 +83,6 @@ import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 
 internal data class StudentInfo(val studentId: String, val firstName: String, val lastName: String)
 
@@ -411,7 +411,7 @@ internal object ChallengePost {
               }
 
             with(UserChallengeInfoTable) {
-              upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+              upsert(userChallengeInfoIndex) { row ->
                 row[userRef] = user.userDbmsId
                 row[md5] = challengeMd5
                 row[updated] = nowInstant()
@@ -423,7 +423,7 @@ internal object ChallengePost {
             // Save the history of each answer on a per-invocation basis
             pairs.forEach { (historyMd5, history) ->
               with(UserAnswerHistoryTable) {
-                upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+                upsert(userAnswerHistoryIndex) { row ->
                   row[userRef] = user.userDbmsId
                   row[md5] = historyMd5
                   row[invocation] = history.invocation.value
@@ -457,7 +457,7 @@ internal object ChallengePost {
       val challengeMd5 = names.md5()
       transaction {
         with(UserChallengeInfoTable) {
-          upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+          upsert(userChallengeInfoIndex) { row ->
             row[userRef] = user.userDbmsId
             row[md5] = challengeMd5
             row[updated] = nowInstant()

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
@@ -100,7 +100,7 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
   fun insert() {
     transaction {
       with(GeoInfosTable) {
-        upsert(geoInfosUnique) { row ->
+        upsert(conflictIndex = geoInfosUnique) { row ->
           row[ip] = remoteHost
           row[json] = this@GeoInfo.json
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
@@ -35,7 +35,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -101,7 +100,7 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
   fun insert() {
     transaction {
       with(GeoInfosTable) {
-        upsert(*geoInfosUnique.columns.toTypedArray()) { row ->
+        upsert(geoInfosUnique) { row ->
           row[ip] = remoteHost
           row[json] = this@GeoInfo.json
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
@@ -21,7 +21,6 @@ import com.pambrose.common.dsl.KtorDsl.get
 import com.pambrose.common.dsl.KtorDsl.withHttpClient
 import com.pambrose.common.exposed.get
 import com.pambrose.common.exposed.readonlyTx
-import com.pambrose.common.exposed.upsert
 import com.readingbat.common.Constants
 import com.readingbat.common.EnvVar
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -36,6 +35,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -101,7 +101,7 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
   fun insert() {
     transaction {
       with(GeoInfosTable) {
-        upsert(conflictIndex = geoInfosUnique) { row ->
+        upsert(*geoInfosUnique.columns.toTypedArray()) { row ->
           row[ip] = remoteHost
           row[json] = this@GeoInfo.json
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/UpsertExtensions.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/UpsertExtensions.kt
@@ -29,6 +29,6 @@ import org.jetbrains.exposed.v1.jdbc.upsert
  * Exposed's upsert directly.
  */
 fun <T : Table> T.upsert(
-  index: Index,
+  conflictIndex: Index,
   body: T.(UpsertStatement<Long>) -> Unit,
-): UpsertStatement<Long> = upsert(keys = index.columns.toTypedArray(), body = body)
+): UpsertStatement<Long> = upsert(keys = conflictIndex.columns.toTypedArray(), body = body)

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/UpsertExtensions.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/UpsertExtensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server
+
+import org.jetbrains.exposed.v1.core.Index
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.UpsertStatement
+import org.jetbrains.exposed.v1.jdbc.upsert
+
+/**
+ * Convenience overload of Exposed's native [upsert] that takes a unique [Index] as the conflict target,
+ * forwarding its columns as the `keys` of the underlying `ON CONFLICT (...)` clause. This keeps the named
+ * index definitions in `PostgresTables.kt` as the single source of truth for conflict columns while using
+ * Exposed's upsert directly.
+ */
+fun <T : Table> T.upsert(
+  index: Index,
+  body: T.(UpsertStatement<Long>) -> Unit,
+): UpsertStatement<Long> = upsert(keys = index.columns.toTypedArray(), body = body)

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
@@ -19,7 +19,6 @@ package com.readingbat.common
 
 import com.pambrose.common.email.Email
 import com.pambrose.common.exposed.readonlyTx
-import com.pambrose.common.exposed.upsert
 import com.readingbat.common.ClassCode.Companion.DISABLED_CLASS_CODE
 import com.readingbat.common.ClassCodeRepository.fetchEnrollees
 import com.readingbat.common.User.Companion.emailCache
@@ -46,6 +45,7 @@ import kotlinx.html.Entities
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 class CodeQualityFixesTest : StringSpec() {
   init {
@@ -110,7 +110,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Insert a like using enum value
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "likedislike-query-md5"
               row[updated] = nowInstant()
@@ -252,7 +252,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Add some challenge data so COUNT queries have rows to count
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[updated] = nowInstant()
@@ -262,7 +262,7 @@ class CodeQualityFixesTest : StringSpec() {
             }
           }
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[invocation] = "test(1)"

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
@@ -33,6 +33,7 @@ import com.readingbat.server.FullName
 import com.readingbat.server.UserAnswerHistoryTable
 import com.readingbat.server.UserChallengeInfoTable
 import com.readingbat.server.UsersTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userAnswerHistoryIndex
 import com.readingbat.server.userChallengeInfoIndex
 import com.readingbat.withTestApp
@@ -45,7 +46,6 @@ import kotlinx.html.Entities
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 
 class CodeQualityFixesTest : StringSpec() {
   init {
@@ -110,7 +110,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Insert a like using enum value
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "likedislike-query-md5"
               row[updated] = nowInstant()
@@ -252,7 +252,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Add some challenge data so COUNT queries have rows to count
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[updated] = nowInstant()
@@ -262,7 +262,7 @@ class CodeQualityFixesTest : StringSpec() {
             }
           }
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[invocation] = "test(1)"

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/CodeQualityFixesTest.kt
@@ -110,7 +110,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Insert a like using enum value
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "likedislike-query-md5"
               row[updated] = nowInstant()
@@ -252,7 +252,7 @@ class CodeQualityFixesTest : StringSpec() {
         // Add some challenge data so COUNT queries have rows to count
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[updated] = nowInstant()
@@ -262,7 +262,7 @@ class CodeQualityFixesTest : StringSpec() {
             }
           }
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "delete-count-md5"
               row[invocation] = "test(1)"

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
@@ -150,7 +150,7 @@ class DateTimeMigrationTest : StringSpec() {
         val firstInsertTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = firstInsertTime
@@ -175,7 +175,7 @@ class DateTimeMigrationTest : StringSpec() {
         val updateTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = updateTime
@@ -216,7 +216,7 @@ class DateTimeMigrationTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = historyMd5
               row[invocation] = invocationText
@@ -256,7 +256,7 @@ class DateTimeMigrationTest : StringSpec() {
         val challengeMd5 = "instantexpr-md5"
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
@@ -24,6 +24,7 @@ import com.readingbat.server.OAuthLinksTable
 import com.readingbat.server.UserAnswerHistoryTable
 import com.readingbat.server.UserChallengeInfoTable
 import com.readingbat.server.UsersTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userAnswerHistoryIndex
 import com.readingbat.server.userChallengeInfoIndex
 import com.readingbat.withTestApp
@@ -37,7 +38,6 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -150,7 +150,7 @@ class DateTimeMigrationTest : StringSpec() {
         val firstInsertTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = firstInsertTime
@@ -175,7 +175,7 @@ class DateTimeMigrationTest : StringSpec() {
         val updateTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = updateTime
@@ -216,7 +216,7 @@ class DateTimeMigrationTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = historyMd5
               row[invocation] = invocationText
@@ -256,7 +256,7 @@ class DateTimeMigrationTest : StringSpec() {
         val challengeMd5 = "instantexpr-md5"
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/DateTimeMigrationTest.kt
@@ -18,9 +18,7 @@
 package com.readingbat.common
 
 import com.pambrose.common.email.Email
-import com.pambrose.common.exposed.get
 import com.pambrose.common.exposed.readonlyTx
-import com.pambrose.common.exposed.upsert
 import com.readingbat.server.FullName
 import com.readingbat.server.OAuthLinksTable
 import com.readingbat.server.UserAnswerHistoryTable
@@ -39,6 +37,7 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -151,7 +150,7 @@ class DateTimeMigrationTest : StringSpec() {
         val firstInsertTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = firstInsertTime
@@ -176,7 +175,7 @@ class DateTimeMigrationTest : StringSpec() {
         val updateTime = nowInstant().truncateToMicros()
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = updateTime
@@ -217,7 +216,7 @@ class DateTimeMigrationTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = historyMd5
               row[invocation] = invocationText
@@ -257,7 +256,7 @@ class DateTimeMigrationTest : StringSpec() {
         val challengeMd5 = "instantexpr-md5"
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
@@ -18,7 +18,6 @@
 package com.readingbat.posts
 
 import com.pambrose.common.email.Email
-import com.pambrose.common.exposed.upsert
 import com.readingbat.common.OAuthProvider
 import com.readingbat.common.User
 import com.readingbat.common.nowInstant
@@ -36,6 +35,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 class AnswerHistoryPersistenceTest : StringSpec() {
   init {
@@ -72,7 +72,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Write answer history
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -109,7 +109,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -142,7 +142,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert two history entries
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5A
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
               row[incorrectAttempts] = 0
               row[historyJson] = Json.encodeToString(listOf("answerA"))
             }
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5B
               row[updated] = nowInstant()
@@ -188,7 +188,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Initial insert
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -205,7 +205,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Upsert with updated data
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -239,7 +239,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert challenge info as incomplete
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -254,7 +254,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Update to all correct
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -284,7 +284,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add challenge info entry
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-challenge-md5"
               row[updated] = nowInstant()
@@ -297,7 +297,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add answer history entry
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-invocation-md5"
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
@@ -72,7 +72,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Write answer history
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -109,7 +109,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -142,7 +142,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert two history entries
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5A
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
               row[incorrectAttempts] = 0
               row[historyJson] = Json.encodeToString(listOf("answerA"))
             }
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5B
               row[updated] = nowInstant()
@@ -188,7 +188,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Initial insert
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -205,7 +205,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Upsert with updated data
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -239,7 +239,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert challenge info as incomplete
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -254,7 +254,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Update to all correct
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -284,7 +284,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add challenge info entry
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-challenge-md5"
               row[updated] = nowInstant()
@@ -297,7 +297,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add answer history entry
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(userAnswerHistoryIndex) { row ->
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-invocation-md5"
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/AnswerHistoryPersistenceTest.kt
@@ -25,6 +25,7 @@ import com.readingbat.server.FullName
 import com.readingbat.server.Invocation
 import com.readingbat.server.UserAnswerHistoryTable
 import com.readingbat.server.UserChallengeInfoTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userAnswerHistoryIndex
 import com.readingbat.server.userChallengeInfoIndex
 import com.readingbat.withTestApp
@@ -35,7 +36,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 
 class AnswerHistoryPersistenceTest : StringSpec() {
   init {
@@ -72,7 +72,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Write answer history
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -109,7 +109,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
 
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -142,7 +142,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert two history entries
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5A
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
               row[incorrectAttempts] = 0
               row[historyJson] = Json.encodeToString(listOf("answerA"))
             }
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = md5B
               row[updated] = nowInstant()
@@ -188,7 +188,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Initial insert
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -205,7 +205,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Upsert with updated data
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserAnswerHistoryTable.md5] = md5
               row[updated] = nowInstant()
@@ -239,7 +239,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Insert challenge info as incomplete
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -254,7 +254,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Update to all correct
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -284,7 +284,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add challenge info entry
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-challenge-md5"
               row[updated] = nowInstant()
@@ -297,7 +297,7 @@ class AnswerHistoryPersistenceTest : StringSpec() {
         // Add answer history entry
         transaction {
           with(UserAnswerHistoryTable) {
-            upsert(*userAnswerHistoryIndex.columns.toTypedArray()) { row ->
+            upsert(userAnswerHistoryIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = "activity-invocation-md5"
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
@@ -24,6 +24,7 @@ import com.readingbat.common.User
 import com.readingbat.common.nowInstant
 import com.readingbat.server.FullName
 import com.readingbat.server.UserChallengeInfoTable
+import com.readingbat.server.upsert
 import com.readingbat.server.userChallengeInfoIndex
 import com.readingbat.withTestApp
 import io.kotest.core.spec.style.StringSpec
@@ -32,7 +33,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.html.Entities
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 
 class LikeDislikePersistenceTest : StringSpec() {
   init {
@@ -65,7 +65,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like (value = 1)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -93,7 +93,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set dislike (value = 2)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -137,7 +137,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Update to dislike
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
@@ -65,7 +65,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like (value = 1)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -93,7 +93,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set dislike (value = 2)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -137,7 +137,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Update to dislike
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/LikeDislikePersistenceTest.kt
@@ -18,7 +18,6 @@
 package com.readingbat.posts
 
 import com.pambrose.common.email.Email
-import com.pambrose.common.exposed.upsert
 import com.readingbat.common.Endpoints
 import com.readingbat.common.OAuthProvider
 import com.readingbat.common.User
@@ -33,6 +32,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.html.Entities
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 class LikeDislikePersistenceTest : StringSpec() {
   init {
@@ -65,7 +65,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like (value = 1)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -93,7 +93,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set dislike (value = 2)
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -137,7 +137,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Set like
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()
@@ -151,7 +151,7 @@ class LikeDislikePersistenceTest : StringSpec() {
         // Update to dislike
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[md5] = challengeMd5
               row[updated] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
@@ -25,7 +25,6 @@ import com.readingbat.withTestApp
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.upsert
 
 class ChallengeProgressServiceTest : StringSpec() {
   init {
@@ -63,7 +62,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()
@@ -93,7 +92,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
+            upsert(userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
@@ -18,7 +18,6 @@
 package com.readingbat.server
 
 import com.pambrose.common.email.Email
-import com.pambrose.common.exposed.upsert
 import com.readingbat.common.OAuthProvider
 import com.readingbat.common.User
 import com.readingbat.common.nowInstant
@@ -26,6 +25,7 @@ import com.readingbat.withTestApp
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 class ChallengeProgressServiceTest : StringSpec() {
   init {
@@ -63,7 +63,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()
@@ -93,7 +93,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(conflictIndex = userChallengeInfoIndex) { row ->
+            upsert(*userChallengeInfoIndex.columns.toTypedArray()) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ChallengeProgressServiceTest.kt
@@ -62,7 +62,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()
@@ -92,7 +92,7 @@ class ChallengeProgressServiceTest : StringSpec() {
 
         transaction {
           with(UserChallengeInfoTable) {
-            upsert(userChallengeInfoIndex) { row ->
+            upsert(conflictIndex = userChallengeInfoIndex) { row ->
               row[userRef] = user.userDbmsId
               row[UserChallengeInfoTable.md5] = md5
               row[created] = nowInstant()


### PR DESCRIPTION
## Summary

Replaces the common-utils `upsert()` wrapper (`com.pambrose.common.exposed.upsert`, which took a `conflictIndex: Index`) with Exposed's native `upsert()` (`org.jetbrains.exposed.v1.jdbc.upsert`, Exposed 1.3.0) at all **30** call sites across 8 files.

To keep the named `Index` definitions in `PostgresTables.kt` as the single source of truth for conflict columns (they were aligned to the DB unique constraints in #94), a thin local overload bridges an `Index` to the native vararg `keys`:

```kotlin
// readingbat-core/.../server/UpsertExtensions.kt
fun <T : Table> T.upsert(
  conflictIndex: Index,
  body: T.(UpsertStatement<Long>) -> Unit,
): UpsertStatement<Long> = upsert(keys = conflictIndex.columns.toTypedArray(), body = body)
```

Call sites read self-documentingly, with no spread operator:

```kotlin
- upsert(conflictIndex = userChallengeInfoIndex) { row -> ... }   // old: common-utils wrapper
+ upsert(conflictIndex = userChallengeInfoIndex) { row -> ... }   // new: local overload -> native Exposed
```

The `keys = ...` named-vararg form mirrors how Exposed's own public `upsert()` forwards its keys internally (`buildStatement { upsert(keys = keys, ...) }`), so this is the library's own idiom rather than a workaround.

## Why it's behavior-preserving

Native `upsert(vararg keys)` with no `onUpdate` emits the same `ON CONFLICT (keys) DO UPDATE SET ...` and updates every inserted column to its `EXCLUDED` value **except** the key columns — identical to common-utils 2.9.0. The `upsert { row -> ... }` bodies are unchanged.

## Notes

- Only the `upsert` import is swapped; `com.pambrose.common.exposed` is still used for `get` / `readonlyTx` / `CustomExpr`, so the dependency stays.
- The overload's `Index`-typed signature doesn't collide with the native `vararg Column<*>` one, so resolution is unambiguous.
- The entirely commented-out legacy `TransferUsers.kt` is left untouched.
- Includes a small unrelated Makefile cleanup (consolidating a `.PHONY` continuation line; no behavior change).

## Commits

1. Convert `upsert()` calls to Exposed's native `upsert()`
2. Replace the `*index.columns.toTypedArray()` spread with an `Index`-accepting overload
3. Use the named `conflictIndex = ...` argument at call sites (+ ktlint formatting in `User.kt`)
4. Consolidate publish/wrapper Makefile targets onto one `.PHONY` line

## Test plan

- `./gradlew check` — full suite green (tests, lint, detekt, Kover verify)
- Targeted persistence tests (`AnswerHistoryPersistenceTest`, `LikeDislikePersistenceTest`, `ChallengeProgressServiceTest`) pass
- No remaining `com.pambrose.common.exposed.upsert` imports or spread operators at call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)