### PR TITLE
Fix server-side Python code injection in answer checking

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/FunctionInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/FunctionInfo.kt
@@ -291,11 +291,15 @@ class FunctionInfo(
      * the server. This parses both sides into elements and compares them with Python's lenient
      * list-equality semantics: whitespace-insensitive, single/double quotes interchangeable
      * (`'a' == "a"`), and numeric values compared by value (`1 == 1.0`).
+     *
+     * A list answer must be bracketed: an unbracketed response (e.g. `False, False`) is malformed
+     * and never matches, consistent with the "Answer should be bracketed" hint.
      */
     internal fun pythonListEquals(userResponse: String, correctAnswer: String): Boolean {
       val lhs = userResponse.trim()
       val rhs = correctAnswer.trim()
-      val lho = if (lhs.isBracketed()) lhs.removeSurrounding("[", "]") else lhs
+      if (lhs.isNotBracketed()) return false
+      val lho = lhs.removeSurrounding("[", "]")
       val rho = if (rhs.isBracketed()) rhs.removeSurrounding("[", "]") else rhs
       val lhElements = parseListElements(lho)
       val rhElements = parseListElements(rho)

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/FunctionInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/FunctionInfo.kt
@@ -53,10 +53,8 @@ import com.readingbat.posts.ChallengeResults
 import com.readingbat.server.ChallengeMd5
 import com.readingbat.server.Invocation
 import com.readingbat.server.LanguageName
-import com.readingbat.server.ScriptPools.pythonEvaluatorPool
 import com.readingbat.utils.toCapitalized
 import io.github.oshai.kotlinlogging.KotlinLogging
-import javax.script.ScriptException
 
 /**
  * Metadata and answer-checking logic for a single challenge function.
@@ -285,25 +283,43 @@ class FunctionInfo(
       return csv.split(",").map { it.trim() }
     }
 
-    private suspend fun String.equalsAsPythonList(correctAnswer: String): Pair<Boolean, String> {
-      fun deriveHint() = if (isNotBracketed()) "Answer should be bracketed" else ""
-      val compareExpr = "${trim()} == ${correctAnswer.trim()}"
-      return runCatching {
-        logger.debug { "Check answers expression: $compareExpr" }
-        val result = pythonEvaluatorPool.eval(compareExpr) as Boolean
-        result to (if (result) "" else deriveHint())
-      }.getOrElse { e ->
-        when (e) {
-          is ScriptException -> {
-            logger.info { "Caught exception comparing $this and $correctAnswer: ${e.message} in: $compareExpr" }
-            false to deriveHint()
-          }
+    /**
+     * Compares two Python list literals for equality without invoking the script engine.
+     *
+     * The previous implementation interpolated the raw user response into a Python expression
+     * and evaluated it via the Jython pool, which let a crafted answer execute arbitrary code on
+     * the server. This parses both sides into elements and compares them with Python's lenient
+     * list-equality semantics: whitespace-insensitive, single/double quotes interchangeable
+     * (`'a' == "a"`), and numeric values compared by value (`1 == 1.0`).
+     */
+    internal fun pythonListEquals(userResponse: String, correctAnswer: String): Boolean {
+      val lhs = userResponse.trim()
+      val rhs = correctAnswer.trim()
+      val lho = if (lhs.isBracketed()) lhs.removeSurrounding("[", "]") else lhs
+      val rho = if (rhs.isBracketed()) rhs.removeSurrounding("[", "]") else rhs
+      val lhElements = parseListElements(lho)
+      val rhElements = parseListElements(rho)
+      return lhElements.size == rhElements.size &&
+        lhElements.zip(rhElements).all { (lh, rh) -> pythonElementEquals(lh, rh) }
+    }
 
-          else -> {
-            false to deriveHint()
-          }
-        }
-      }
+    private fun pythonElementEquals(lhs: String, rhs: String): Boolean {
+      if (lhs == rhs) return true
+      // Numbers compare by value so 1 == 1.0 and 1.0 == 1.00, matching Python.
+      val lhsNum = lhs.toDoubleOrNull()
+      val rhsNum = rhs.toDoubleOrNull()
+      if (lhsNum != null && rhsNum != null) return lhsNum == rhsNum
+      // Strings: single and double quotes are interchangeable in Python.
+      return lhs.normalizeQuotes() == rhs.normalizeQuotes()
+    }
+
+    private fun String.normalizeQuotes() = if (isSingleQuoted()) singleToDoubleQuoted() else this
+
+    private fun String.equalsAsPythonList(correctAnswer: String): Pair<Boolean, String> {
+      fun deriveHint() = if (isNotBracketed()) "Answer should be bracketed" else ""
+      val result = pythonListEquals(this, correctAnswer)
+      logger.debug { "Check Python answers list comparison: $this == $correctAnswer -> $result" }
+      return result to (if (result) "" else deriveHint())
     }
 
     private fun String.equalsAsJvmScalar(

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/PythonListComparisonTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/PythonListComparisonTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.common
+
+import com.readingbat.common.FunctionInfo.Companion.pythonListEquals
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [FunctionInfo.pythonListEquals], the eval-free replacement for the former
+ * `pythonEvaluatorPool.eval` comparison. The previous implementation interpolated raw user
+ * input into a Python expression and executed it, which was a remote-code-execution surface.
+ * These tests pin down the behavior the pure comparison must preserve (Python's lenient list
+ * equality) and verify that malicious payloads are treated as inert, non-matching data.
+ */
+class PythonListComparisonTest : StringSpec() {
+  init {
+    "identical int lists are equal" {
+      pythonListEquals("[1, 2, 3]", "[1, 2, 3]") shouldBe true
+    }
+
+    "differing whitespace does not matter" {
+      pythonListEquals("[1,2,3]", "[1, 2, 3]") shouldBe true
+    }
+
+    "single and double quoted strings are equal" {
+      pythonListEquals("['a', 'b']", """["a", "b"]""") shouldBe true
+    }
+
+    "int and float forms of the same number are equal" {
+      pythonListEquals("[1.0, 2.0]", "[1, 2]") shouldBe true
+    }
+
+    "boolean lists are equal" {
+      pythonListEquals("[True, False]", "[True, False]") shouldBe true
+    }
+
+    "empty lists are equal" {
+      pythonListEquals("[]", "[]") shouldBe true
+    }
+
+    "surrounding whitespace around the whole list is ignored" {
+      pythonListEquals("  [1, 2, 3]  ", "[1, 2, 3]") shouldBe true
+    }
+
+    "lists of different length are not equal" {
+      pythonListEquals("[1, 2]", "[1, 2, 3]") shouldBe false
+    }
+
+    "lists with a differing element are not equal" {
+      pythonListEquals("[1, 2, 4]", "[1, 2, 3]") shouldBe false
+    }
+
+    "different string values are not equal" {
+      pythonListEquals("""["a", "b"]""", """["a", "c"]""") shouldBe false
+    }
+
+    "empty list does not equal non-empty list" {
+      pythonListEquals("[]", "[1]") shouldBe false
+    }
+
+    // Security: a code-injection payload must be treated as inert data, never evaluated,
+    // and must not match a legitimate answer.
+    "code injection payload is inert and returns false" {
+      pythonListEquals("__import__('os').system('echo pwned')", "[1, 2]") shouldBe false
+    }
+
+    "bracketed code injection payload is inert and returns false" {
+      pythonListEquals("[__import__('subprocess').call(['ls'])]", "[1]") shouldBe false
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/PythonListComparisonTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/PythonListComparisonTest.kt
@@ -74,6 +74,16 @@ class PythonListComparisonTest : StringSpec() {
       pythonListEquals("[]", "[1]") shouldBe false
     }
 
+    // A list answer must be bracketed; otherwise it is malformed and incorrect, even if its
+    // comma-separated contents would match. The old eval-based path rejected these for free.
+    "an unbracketed answer is not equal to a bracketed list" {
+      pythonListEquals("False, False", "[False, False]") shouldBe false
+    }
+
+    "an unbracketed single value is not equal to a bracketed list" {
+      pythonListEquals("1", "[1]") shouldBe false
+    }
+
     // Security: a code-injection payload must be treated as inert data, never evaluated,
     // and must not match a legitimate answer.
     "code injection payload is inert and returns false" {


### PR DESCRIPTION
## Summary
`equalsAsPythonList` interpolated the raw user answer into a Python expression and evaluated it via the Jython pool, allowing a crafted answer (e.g. `__import__('os').system(...)`) to execute arbitrary code on the server.

## Fix
Replace the `eval` with a pure, eval-free element-wise comparison (`pythonListEquals`), mirroring the JVM path that already avoids the script engine. Preserves Python's lenient list-equality semantics: whitespace-insensitive, single/double quotes interchangeable (`'a' == "a"`), and numeric value equality (`1 == 1.0`). Malicious payloads are now parsed as inert data and marked incorrect, never executed.

## Testing
- New `PythonListComparisonTest` (13 cases): equality semantics, mismatches, empty lists, surrounding whitespace, and two code-injection payloads proving inertness (TDD: written against a stub to watch them fail first).
- `EndpointTest > Test all challenges` (Python array answers over the full HTTP path) passes.
- lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)