### PR TITLE
Fix stored XSS in teacher dashboard answer updates

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/AnswerPublisher.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/AnswerPublisher.kt
@@ -29,6 +29,7 @@ import com.readingbat.server.ws.PubSubCommandsWs.PubSubTopic.LIKE_DISLIKE
 import com.readingbat.server.ws.PubSubCommandsWs.PubSubTopic.USER_ANSWERS
 import com.readingbat.utils.toJson
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 
 /**
  * Publishes real-time answer updates and like/dislike events to teacher dashboards via WebSocket.
@@ -41,6 +42,16 @@ internal object AnswerPublisher {
   private val logger = KotlinLogging.logger {}
 
   private val wsFlow get() = if (isMultiServerEnabled()) multiServerWsWriteFlow else singleServerWsFlow
+
+  /**
+   * Builds the answer-history string sent to the teacher dashboard, most-recent first.
+   *
+   * The dashboard renders this value via `innerHTML` on a live WebSocket update, so each student
+   * answer is HTML-escaped to prevent stored XSS. Only the `<br>` separators between answers remain
+   * live markup, mirroring the (already-escaped) server-side initial render.
+   */
+  internal fun formatDashboardAnswers(answers: List<String>, maxHistoryLength: Int): String =
+    answers.asReversed().take(maxHistoryLength).joinToString("<br>") { escapeHtml4(it) }
 
   /** Publishes a student's answer update for a specific challenge invocation to the teacher's dashboard. */
   suspend fun publishAnswers(
@@ -56,7 +67,7 @@ internal object AnswerPublisher {
       DashboardHistory(
         history.invocation.value,
         history.correct,
-        history.answers.asReversed().take(maxHistoryLength).joinToString("<br>"),
+        formatDashboardAnswers(history.answers, maxHistoryLength),
       )
     val targetName = classTargetName(user.enrolledClassCode, challengeMd5)
     val dashboardInfo = DashboardInfo(user.userId, complete, numCorrect, dashboardHistory)

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/AnswerPublisherTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/AnswerPublisherTest.kt
@@ -20,10 +20,38 @@ package com.readingbat.common
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
 import kotlin.reflect.full.declaredMemberFunctions
+import io.kotest.matchers.string.shouldContain as shouldContainSubstring
+import io.kotest.matchers.string.shouldNotContain as shouldNotContainSubstring
 
 class AnswerPublisherTest : StringSpec() {
   init {
+    // The teacher dashboard renders this string via innerHTML over a WebSocket, so student
+    // answers must be HTML-escaped to prevent stored XSS, while the <br> separators stay literal.
+    "formatDashboardAnswers reverses, limits, and joins answers with <br>" {
+      AnswerPublisher.formatDashboardAnswers(listOf("a", "b", "c"), 2) shouldBe "c<br>b"
+    }
+
+    "formatDashboardAnswers leaves a plain answer unchanged" {
+      AnswerPublisher.formatDashboardAnswers(listOf("42"), 10) shouldBe "42"
+    }
+
+    "formatDashboardAnswers returns empty string for no answers" {
+      AnswerPublisher.formatDashboardAnswers(emptyList(), 10) shouldBe ""
+    }
+
+    "formatDashboardAnswers HTML-escapes a script-injection answer" {
+      val result = AnswerPublisher.formatDashboardAnswers(listOf("<img src=x onerror=alert(1)>"), 10)
+      result shouldNotContainSubstring "<img"
+      result shouldContainSubstring "&lt;img"
+    }
+
+    "formatDashboardAnswers keeps the <br> separator literal between escaped answers" {
+      val result = AnswerPublisher.formatDashboardAnswers(listOf("<b>x", "<b>y"), 10)
+      result shouldBe "&lt;b&gt;y<br>&lt;b&gt;x"
+    }
+
     "AnswerPublisher should declare publishAnswers" {
       val methodNames = AnswerPublisher::class.declaredMemberFunctions.map { it.name }
       methodNames shouldContain "publishAnswers"


### PR DESCRIPTION
## Summary
`publishAnswers` joined raw student answers with `<br>` and sent them to the teacher dashboard, which renders the value via `innerHTML` on each live WebSocket update. A crafted answer (e.g. `<img src=x onerror=...>`) would execute arbitrary JavaScript in the teacher's browser.

## Fix
Extract `formatDashboardAnswers` and HTML-escape each answer with `escapeHtml4` before joining, leaving only the `<br>` separators as live markup. This matches the server-side initial render, which already escapes answers via kotlinx.html.

## Testing
- Added `formatDashboardAnswers` tests to `AnswerPublisherTest`: ordering/limit/join behavior and that an injection payload is escaped (TDD: written against the old unescaped behavior to watch the injection test fail first).
- `EndpointTest` passes; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)