### PR TITLE
Fix JS injection via student name in remove-from-class confirm()

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
@@ -82,6 +82,7 @@ import kotlinx.html.table
 import kotlinx.html.td
 import kotlinx.html.th
 import kotlinx.html.tr
+import org.apache.commons.text.StringEscapeUtils.escapeEcmaScript
 
 /**
  * Generates the individual student summary page at `/studentsummary`.
@@ -166,11 +167,21 @@ internal object StudentSummaryPage {
       }
   }
 
+  /**
+   * Builds the inline `onSubmit` confirmation handler for the remove-from-class button.
+   *
+   * The student name is user-controlled and is embedded inside a single-quoted JS string literal,
+   * so it is escaped with [escapeEcmaScript] to neutralize quotes and other JS metacharacters and
+   * prevent script injection into the teacher's page.
+   */
+  internal fun confirmRemovalScript(studentName: String): String =
+    "return confirm('Are you sure you want to remove ${escapeEcmaScript(studentName)} from the class?')"
+
   internal fun BODY.removeFromClassButton(student: User, studentName: String) {
     form(classes = "m-0") {
       action = TEACHER_PREFS_ENDPOINT
       method = post
-      onSubmit = "return confirm('Are you sure you want to remove $studentName from the class?')"
+      onSubmit = confirmRemovalScript(studentName)
       hiddenInput {
         name = USER_ID_PARAM
         value = student.userId

--- a/readingbat-core/src/test/kotlin/com/readingbat/pages/StudentSummaryPageTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/pages/StudentSummaryPageTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.pages
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [StudentSummaryPage.confirmRemovalScript], which builds the inline `onSubmit`
+ * confirm() handler for the remove-from-class button. The student name is user-controlled, so a
+ * name containing a single quote (or other JS metacharacters) must be escaped to prevent it from
+ * breaking out of the JS string literal and injecting script into the teacher's page.
+ */
+class StudentSummaryPageTest : StringSpec() {
+  init {
+    "confirmRemovalScript embeds a plain name verbatim" {
+      StudentSummaryPage.confirmRemovalScript("Ada Lovelace") shouldBe
+        "return confirm('Are you sure you want to remove Ada Lovelace from the class?')"
+    }
+
+    "confirmRemovalScript escapes quotes so a name cannot break out of the JS string" {
+      // Every injected apostrophe is backslash-escaped, so it stays inside the confirm() literal
+      // instead of terminating it and starting an alert() call.
+      StudentSummaryPage.confirmRemovalScript("'); alert(document.cookie); ('") shouldBe
+        "return confirm('Are you sure you want to remove \\'); alert(document.cookie); (\\' from the class?')"
+    }
+
+    "confirmRemovalScript escapes an apostrophe in a real name" {
+      StudentSummaryPage.confirmRemovalScript("O'Brien") shouldBe
+        "return confirm('Are you sure you want to remove O\\'Brien from the class?')"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The remove-from-class button interpolated the user-controlled student full name directly into a single-quoted JS string in the inline `onSubmit` confirm() handler. A name containing an apostrophe (e.g. `'); alert(document.cookie); ('`) could break out of the string literal and execute arbitrary script in the teacher's browser.

## Fix
Extract `confirmRemovalScript` and escape the name with `escapeEcmaScript` so quotes and other JS metacharacters stay inside the string literal.

## Testing
- New `StudentSummaryPageTest`: a plain name (verbatim), an apostrophe in a real name (`O\'Brien`), and a quote-breakout payload asserted by exact escaped output (TDD: written against the unescaped form to watch the injection tests fail first).
- `pages.*` tests + `EndpointTest` pass; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)