### PR TITLE
Enforce rate limiting with a global per-IP limiter

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Installs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Installs.kt
@@ -62,6 +62,7 @@ import io.ktor.server.plugins.forwardedheaders.ForwardedHeaders
 import io.ktor.server.plugins.forwardedheaders.XForwardedHeaders
 import io.ktor.server.plugins.origin
 import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitConfig
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.path
 import io.ktor.server.request.uri
@@ -86,6 +87,26 @@ import kotlin.time.Duration.Companion.seconds
 object Installs {
   private val logger = KotlinLogging.logger {}
   private val excludedEndpoints = listOf("/$STATIC/", "$WS_ROOT/")
+
+  /**
+   * Paths excluded from rate limiting: static assets, WebSocket upgrades, and health pings.
+   * These are high-volume legitimate traffic that should not consume a client's request budget.
+   */
+  internal fun isRateLimitExcluded(path: String): Boolean =
+    path == PING_ENDPOINT || excludedEndpoints.any { path.startsWith(it) }
+
+  /**
+   * Configures a global rate limiter keyed per client IP, so that every request (not just routes
+   * wrapped in `rateLimit { }`) is throttled. Requests to [isRateLimitExcluded] paths are given a
+   * weight of 0 so they never consume tokens, leaving normal browsing of static assets unaffected.
+   */
+  internal fun RateLimitConfig.configureGlobalRateLimit(limit: Int, refillSeconds: Int) {
+    global {
+      rateLimiter(limit = limit, refillPeriod = refillSeconds.seconds)
+      requestKey { call -> call.request.origin.remoteHost }
+      requestWeight { call, _ -> if (isRateLimitExcluded(call.request.path())) 0 else 1 }
+    }
+  }
 
   /** Installs all Ktor plugins. OAuth providers are auto-configured when credentials are present; [production] controls cookie security and HTTPS redirect. */
   fun Application.installs(production: Boolean) {
@@ -149,13 +170,19 @@ object Installs {
       }
     }
 
-    install(RateLimit) {
-      register {
-        rateLimiter(
+    // Rate limiting is enforced in production only, mirroring the other production-gated
+    // hardening here (HSTS, secure cookies, HTTPS redirect). The limiter is global and keyed per
+    // client IP; static/WebSocket/ping traffic is excluded so normal browsing is not throttled.
+    if (production) {
+      logger.info { "Installing global rate limiter" }
+      install(RateLimit) {
+        configureGlobalRateLimit(
           limit = EnvVar.RATE_LIMIT_COUNT.getEnv(10),
-          refillPeriod = EnvVar.RATE_LIMIT_SECS.getEnv(1).seconds,
+          refillSeconds = EnvVar.RATE_LIMIT_SECS.getEnv(1),
         )
       }
+    } else {
+      logger.info { "Not installing rate limiter (non-production)" }
     }
 
     fun String.startsWithList(prefixes: Iterable<String>) = prefixes.any { startsWith(it) }

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/RateLimitInstallTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/RateLimitInstallTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server
+
+import com.readingbat.common.Endpoints.PING_ENDPOINT
+import com.readingbat.server.Installs.configureGlobalRateLimit
+import com.readingbat.server.Installs.isRateLimitExcluded
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.HttpStatusCode.Companion.TooManyRequests
+import io.ktor.server.application.install
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+
+/**
+ * Tests for the global rate limiter wiring. The limiter was previously registered as a named
+ * provider that no route ever applied (`register {}` instead of `global {}`), so it never
+ * enforced anything. These tests verify that the limiter actually throttles dynamic requests and
+ * that high-volume static/WebSocket/ping traffic is excluded so normal browsing is unaffected.
+ */
+class RateLimitInstallTest : StringSpec() {
+  init {
+    "isRateLimitExcluded excludes static, websocket, and ping paths" {
+      isRateLimitExcluded("/static/css/styles.css") shouldBe true
+      isRateLimitExcluded("/ws/challenge/abc") shouldBe true
+      isRateLimitExcluded(PING_ENDPOINT) shouldBe true
+    }
+
+    "isRateLimitExcluded does not exclude dynamic content paths" {
+      isRateLimitExcluded("/content/java/Warmup-1/hello") shouldBe false
+      isRateLimitExcluded("/") shouldBe false
+    }
+
+    "global rate limiter returns 429 once a client exceeds the limit on a dynamic path" {
+      testApplication {
+        install(RateLimit) { configureGlobalRateLimit(limit = 3, refillSeconds = 60) }
+        routing {
+          get("/content/test") { call.respondText("ok") }
+        }
+        repeat(3) { client.get("/content/test").status shouldBe OK }
+        client.get("/content/test").status shouldBe TooManyRequests
+      }
+    }
+
+    "global rate limiter never throttles excluded static paths" {
+      testApplication {
+        install(RateLimit) { configureGlobalRateLimit(limit = 3, refillSeconds = 60) }
+        routing {
+          get("/static/asset") { call.respondText("asset") }
+        }
+        repeat(10) { client.get("/static/asset").status shouldBe OK }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The RateLimit plugin used `register {}`, which creates a named provider that only applies to routes wrapped in `rateLimit { }`. No route wrapped it, so rate limiting was never enforced. The default key was also a single shared bucket, which would have throttled all clients together.

## Fix
Switch to a `global { }` limiter keyed per client IP so every request is throttled, and give static/WebSocket/ping paths a weight of 0 so high-volume legitimate traffic does not consume a client's budget. Enforcement is gated on `production`, mirroring the other production-only hardening here (HSTS, secure cookies, HTTPS redirect), so dev and tests are not throttled. Limits remain env-tunable via `RATE_LIMIT_COUNT` / `RATE_LIMIT_SECS`.

## Testing
- New `RateLimitInstallTest`: the exclusion predicate, actual 429 throttling after exceeding the limit on a dynamic path, and excluded static paths never throttled (TDD: written against inert stubs to watch them fail first).
- `EndpointTest` passes unchanged, confirming the production gate prevents test-suite throttling; lint + detekt clean.

## Note
Enforcement is production-only by design. Keyed per IP, so students behind one shared/NAT school IP share a bucket — raise `RATE_LIMIT_COUNT` to mitigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)