### PR TITLE
Sign and encrypt session cookies

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
@@ -54,6 +54,7 @@ enum class EnvVar(val maskFunc: EnvVar.() -> String = { getEnv(UNASSIGNED) }) {
   XFORWARDED_ENABLED,
   RATE_LIMIT_COUNT,
   RATE_LIMIT_SECS,
+  SESSION_SECRET({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
   ;
 
   /** Returns true if this environment variable is set. */

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
@@ -430,6 +430,14 @@ sealed class Property(
       maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
     )
 
+  /** Secret used to sign and encrypt session cookies. Required in production; see ConfigureCookies. */
+  object SESSION_SECRET :
+    Property(
+      propertyValue = "$READINGBAT.$SITE.sessionSecret",
+      initFunc = { setProperty(EnvVar.SESSION_SECRET.getEnv(configValue(it, ""))) },
+      maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
+    )
+
   companion object {
     val envResendApiKey: String by lazy { RESEND_API_KEY.getRequiredProperty() }
     val envResendSender: Email by lazy { RESEND_SENDER_EMAIL.getRequiredProperty().toResendEmail() }
@@ -472,6 +480,7 @@ sealed class Property(
         GITHUB_OAUTH_CLIENT_SECRET,
         GOOGLE_OAUTH_CLIENT_ID,
         GOOGLE_OAUTH_CLIENT_SECRET,
+        SESSION_SECRET,
       )
   }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ConfigureCookies.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ConfigureCookies.kt
@@ -21,8 +21,10 @@ import com.readingbat.common.AuthName.AUTH_COOKIE
 import com.readingbat.common.BrowserSession
 import com.readingbat.common.OAuthReturnUrl
 import com.readingbat.common.UserPrincipal
+import io.ktor.server.sessions.SessionTransportTransformerEncrypt
 import io.ktor.server.sessions.SessionsConfig
 import io.ktor.server.sessions.cookie
+import java.security.MessageDigest
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -34,8 +36,45 @@ import kotlin.time.Duration.Companion.days
  * SameSite=Lax for CSRF protection and are marked httpOnly and secure in production.
  */
 internal object ConfigureCookies {
+  /**
+   * Insecure placeholder secret used only for local development and tests. Production must override
+   * it via the `SESSION_SECRET` environment variable; [resolveSessionSecret] refuses to start
+   * otherwise.
+   */
+  internal const val DEV_SESSION_SECRET = "readingbat-insecure-dev-session-secret-change-me"
+
+  /**
+   * Returns the session secret to key cookie signing/encryption with. In production an unset
+   * (blank) secret aborts startup, since running with no key would let anyone forge an
+   * authentication cookie. Outside production a blank secret falls back to [DEV_SESSION_SECRET].
+   */
+  internal fun resolveSessionSecret(production: Boolean, configured: String): String =
+    when {
+      configured.isNotBlank() -> configured
+      production -> error("SESSION_SECRET must be set in production: session cookies cannot be secured without a key")
+      else -> DEV_SESSION_SECRET
+    }
+
+  /**
+   * Derives a fixed-size key from [secret] for a given [purpose] via SHA-256. Distinct purposes
+   * (and cookie names) yield independent keys, so a token minted for one cookie cannot be replayed
+   * as another.
+   */
+  internal fun deriveKey(secret: String, purpose: String, size: Int): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest("$secret:$purpose".toByteArray()).copyOf(size)
+
+  /**
+   * Builds the transformer that encrypts (AES-128) and then signs (HMAC-SHA256) a cookie's
+   * contents, using keys derived from [secret] and bound to [cookieName].
+   */
+  internal fun sessionTransformer(secret: String, cookieName: String): SessionTransportTransformerEncrypt =
+    SessionTransportTransformerEncrypt(
+      deriveKey(secret, "encrypt:$cookieName", 16),
+      deriveKey(secret, "sign:$cookieName", 32),
+    )
+
   /** Configures the anonymous browser session ID cookie used for tracking sessions before login. */
-  fun SessionsConfig.configureSessionIdCookie(production: Boolean) {
+  fun SessionsConfig.configureSessionIdCookie(production: Boolean, secret: String) {
     cookie<BrowserSession>("readingbat_session_id") {
       // storage = RedisSessionStorage(redis = pool.resource)) {
       // storage = directorySessionStorage(File("server-sessions"), cached = true)) {
@@ -47,11 +86,13 @@ internal object ConfigureCookies {
       // uploads, and changing settings, use "unsafe" HTTP verbs like POST and PUT, not GET or HEAD.
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies
       cookie.extensions["SameSite"] = "lax"
+
+      transform(sessionTransformer(secret, "readingbat_session_id"))
     }
   }
 
   /** Configures the authentication cookie that persists the [UserPrincipal] across requests. */
-  fun SessionsConfig.configureAuthCookie(production: Boolean) {
+  fun SessionsConfig.configureAuthCookie(production: Boolean, secret: String) {
     cookie<UserPrincipal>(name = AUTH_COOKIE) {
       cookie.path = "/" // CHALLENGE_ROOT + "/"
       cookie.httpOnly = true
@@ -63,17 +104,21 @@ internal object ConfigureCookies {
       // uploads, and changing settings, use "unsafe" HTTP verbs like POST and PUT, not GET or HEAD.
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies
       cookie.extensions["SameSite"] = "lax"
+
+      transform(sessionTransformer(secret, AUTH_COOKIE))
     }
   }
 
   /** Configures a short-lived cookie to preserve the return URL across the OAuth redirect flow. */
-  fun SessionsConfig.configureOAuthReturnUrlCookie(production: Boolean) {
+  fun SessionsConfig.configureOAuthReturnUrlCookie(production: Boolean, secret: String) {
     cookie<OAuthReturnUrl>("readingbat_oauth_return") {
       cookie.path = "/"
       cookie.httpOnly = true
       if (production) cookie.secure = true
       cookie.maxAgeInSeconds = 600 // 10 min — survives OAuth round-trip
       cookie.extensions["SameSite"] = "lax"
+
+      transform(sessionTransformer(secret, "readingbat_oauth_return"))
     }
   }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/Installs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/Installs.kt
@@ -37,6 +37,7 @@ import com.readingbat.pages.NotFoundPage.notFoundPage
 import com.readingbat.server.ConfigureCookies.configureAuthCookie
 import com.readingbat.server.ConfigureCookies.configureOAuthReturnUrlCookie
 import com.readingbat.server.ConfigureCookies.configureSessionIdCookie
+import com.readingbat.server.ConfigureCookies.resolveSessionSecret
 import com.readingbat.server.ConfigureOAuth.configureGitHubOAuth
 import com.readingbat.server.ConfigureOAuth.configureGoogleOAuth
 import com.readingbat.server.ReadingBatServer.serverSessionId
@@ -112,10 +113,12 @@ object Installs {
   fun Application.installs(production: Boolean) {
     install(Resources)
 
+    val sessionSecret =
+      resolveSessionSecret(production, Property.SESSION_SECRET.getProperty("", errorOnNonInit = false))
     install(Sessions) {
-      configureSessionIdCookie(production)
-      configureAuthCookie(production)
-      configureOAuthReturnUrlCookie(production)
+      configureSessionIdCookie(production, sessionSecret)
+      configureAuthCookie(production, sessionSecret)
+      configureOAuthReturnUrlCookie(production, sessionSecret)
     }
 
     install(Authentication) {

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ConfigureCookiesTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ConfigureCookiesTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server
+
+import com.readingbat.common.UserPrincipal
+import com.readingbat.server.ConfigureCookies.DEV_SESSION_SECRET
+import com.readingbat.server.ConfigureCookies.deriveKey
+import com.readingbat.server.ConfigureCookies.resolveSessionSecret
+import com.readingbat.server.ConfigureCookies.sessionTransformer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.application.install
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.sessions.get
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.testApplication
+
+/**
+ * Tests for [ConfigureCookies] session-cookie hardening. The auth/session cookies were previously
+ * stored as plaintext, so a [UserPrincipal] (carrying a userId) could be forged or read. These
+ * tests pin down the secret-resolution fail-fast, the key derivation, and the end-to-end property
+ * that a tampered/plaintext cookie is rejected while a legitimately set session round-trips.
+ */
+class ConfigureCookiesTest : StringSpec() {
+  init {
+    "resolveSessionSecret falls back to the dev default when unset in dev" {
+      resolveSessionSecret(production = false, configured = "") shouldBe DEV_SESSION_SECRET
+    }
+
+    "resolveSessionSecret returns a custom secret" {
+      resolveSessionSecret(production = false, configured = "custom") shouldBe "custom"
+      resolveSessionSecret(production = true, configured = "a-real-production-secret") shouldBe
+        "a-real-production-secret"
+    }
+
+    "resolveSessionSecret fails fast when unset in production" {
+      shouldThrow<IllegalStateException> {
+        resolveSessionSecret(production = true, configured = "")
+      }
+    }
+
+    "deriveKey is deterministic and sized" {
+      deriveKey("secret", "sign", 32).size shouldBe 32
+      deriveKey("secret", "encrypt", 16).size shouldBe 16
+      deriveKey("secret", "sign", 32) shouldBe deriveKey("secret", "sign", 32)
+    }
+
+    "deriveKey produces distinct keys per purpose and per secret" {
+      deriveKey("secret", "sign", 32) shouldNotBe deriveKey("secret", "encrypt", 32)
+      deriveKey("secret-a", "sign", 32) shouldNotBe deriveKey("secret-b", "sign", 32)
+    }
+
+    "a legitimately set session round-trips through the transformer" {
+      testApplication {
+        install(Sessions) {
+          cookie<UserPrincipal>("test_auth") { transform(sessionTransformer("a-secret", "test_auth")) }
+        }
+        routing {
+          get("/set") {
+            call.sessions.set(UserPrincipal("user-1"))
+            call.respondText("ok")
+          }
+          get("/whoami") { call.respondText(call.sessions.get<UserPrincipal>()?.userId ?: "none") }
+        }
+        val client = createClient { install(HttpCookies) }
+        client.get("/set")
+        client.get("/whoami").bodyAsText() shouldBe "user-1"
+      }
+    }
+
+    "a forged plaintext cookie is rejected" {
+      testApplication {
+        install(Sessions) {
+          cookie<UserPrincipal>("test_auth") { transform(sessionTransformer("a-secret", "test_auth")) }
+        }
+        routing {
+          get("/whoami") { call.respondText(call.sessions.get<UserPrincipal>()?.userId ?: "none") }
+        }
+        // An attacker-crafted plaintext principal has no valid signature/ciphertext and is ignored.
+        val response = client.get("/whoami") { header("Cookie", "test_auth=userId%3Dadmin%26created%3D0") }
+        response.bodyAsText() shouldBe "none"
+      }
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/CookieSecurityTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/CookieSecurityTest.kt
@@ -32,11 +32,14 @@ class CookieSecurityTest : StringSpec() {
   init {
     afterEach {
       Property.IS_PRODUCTION.setProperty("false")
+      Property.SESSION_SECRET.setProperty("")
     }
 
     "Cookies have Secure flag in production mode" {
       initTestProperties()
       Property.IS_PRODUCTION.setProperty("true")
+      // Production refuses to start without a session secret, so provide one for the test.
+      Property.SESSION_SECRET.setProperty("test-session-secret")
 
       TestData.readTestContent()
         .also { testContent ->


### PR DESCRIPTION
## Summary
The browser-session, auth, and OAuth-return cookies were stored as plaintext with no transformer, so the `UserPrincipal` (carrying `userId`) could be forged or read — enabling auth bypass / privilege escalation.

## Fix
Apply `SessionTransportTransformerEncrypt` (AES-128 encrypt + HMAC-SHA256 sign) to all three cookies, with keys derived from a secret via SHA-256 and **bound per cookie name** so a token minted for one cookie cannot be replayed as another. The secret comes from `SESSION_SECRET` (env var or HOCON `readingbat.site.sessionSecret`); **production refuses to start without it**, while dev/test fall back to an insecure built-in default.

## Testing
- New `ConfigureCookiesTest` (TDD): production fail-fast, key derivation (deterministic/sized/distinct), a legitimate session **round-trip**, and a **forged plaintext cookie rejected**.
- Updated `CookieSecurityTest` to provide a secret for its production-mode case.
- Full `readingbat-core` suite green locally; lint + detekt clean.

## ⚠️ Deploy notes
- **Set `SESSION_SECRET`** in production (shared across nodes for multi-server) or the server won't start.
- This **invalidates existing cookies** — users are logged out once on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)