### PR TITLE
Enforce class ownership on teacher class-management actions

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
@@ -265,6 +265,9 @@ class User {
       }
     }
 
+  /** Returns true if [classCode] is a valid class taught (owned) by this user. */
+  fun ownsClass(classCode: ClassCode) = classCode.isEnabled && classCode.fetchClassTeacherId() == userId
+
   fun isInDbms() =
     readonlyTx {
       with(UsersTable) {

--- a/readingbat-core/src/main/kotlin/com/readingbat/posts/TeacherPrefsPost.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/posts/TeacherPrefsPost.kt
@@ -47,6 +47,7 @@ import com.readingbat.common.User.Companion.queryActiveTeachingClassCode
 import com.readingbat.common.User.Companion.queryPreviousTeacherClassCode
 import com.readingbat.common.User.Companion.toUser
 import com.readingbat.common.isValidUser
+import com.readingbat.dsl.InvalidRequestException
 import com.readingbat.dsl.ReadingBatContent
 import com.readingbat.pages.ClassSummaryPage.classSummaryPage
 import com.readingbat.pages.TeacherPrefsPage.teacherPrefsPage
@@ -96,6 +97,9 @@ internal object TeacherPrefsPost {
           val studentId = params[USER_ID_PARAM] ?: error("Missing: $USER_ID_PARAM")
           val student = studentId.toUser()
           val classCode = student.enrolledClassCode
+          // Only the teacher who owns the student's class may remove the student from it.
+          if (!user.ownsClass(classCode))
+            throw InvalidRequestException("User ${user.userId} does not own class $classCode")
           student.withdrawFromClass(classCode)
           val msg = "${student.fullName} removed from class ${classCode.toDisplayString()}"
           logger.info { msg }
@@ -165,6 +169,11 @@ internal object TeacherPrefsPost {
 
   private fun updateActiveClass(user: User, classCode: ClassCode) =
     when {
+      // A teacher may only make their own class active; disabling (student mode) is always allowed.
+      classCode.isEnabled && !user.ownsClass(classCode) -> {
+        throw InvalidRequestException("User ${user.userId} does not own class $classCode")
+      }
+
       // Do not allow this for classCode.isStudentMode because turns off the
       // student/teacher toggle mode
       queryActiveTeachingClassCode(user) == classCode && classCode.isEnabled -> {
@@ -194,6 +203,10 @@ internal object TeacherPrefsPost {
           user,
           Message("Invalid class code: $classCode", true),
         )
+      }
+
+      !user.ownsClass(classCode) -> {
+        throw InvalidRequestException("User ${user.userId} does not own class $classCode")
       }
 
       else -> {

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/ClassManagementTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/ClassManagementTest.kt
@@ -223,5 +223,59 @@ class ClassManagementTest : StringSpec() {
         DISABLED_CLASS_CODE.fetchEnrollees().shouldBeEmpty()
       }
     }
+
+    "ownsClass returns true for a class the teacher created" {
+      withTestApp {
+        val teacher =
+          User.createOAuthUser(
+            name = FullName("Owner Teacher"),
+            emailVal = Email("owner-teacher@test.com"),
+            provider = OAuthProvider.GITHUB,
+            providerId = "owner-teacher-001",
+          )
+        val classCode = ClassCode.newClassCode()
+        teacher.addClassCode(classCode, "Owned Class")
+
+        teacher.ownsClass(classCode) shouldBe true
+      }
+    }
+
+    "ownsClass returns false for a class owned by another teacher" {
+      withTestApp {
+        val owner =
+          User.createOAuthUser(
+            name = FullName("Real Owner"),
+            emailVal = Email("real-owner@test.com"),
+            provider = OAuthProvider.GITHUB,
+            providerId = "real-owner-001",
+          )
+        val attacker =
+          User.createOAuthUser(
+            name = FullName("Attacker Teacher"),
+            emailVal = Email("attacker-teacher@test.com"),
+            provider = OAuthProvider.GITHUB,
+            providerId = "attacker-teacher-001",
+          )
+        val classCode = ClassCode.newClassCode()
+        owner.addClassCode(classCode, "Owner's Class")
+
+        attacker.ownsClass(classCode) shouldBe false
+      }
+    }
+
+    "ownsClass returns false for a disabled or nonexistent class" {
+      withTestApp {
+        val teacher =
+          User.createOAuthUser(
+            name = FullName("No Class Teacher"),
+            emailVal = Email("no-class-teacher@test.com"),
+            provider = OAuthProvider.GITHUB,
+            providerId = "no-class-teacher-001",
+          )
+
+        teacher.ownsClass(DISABLED_CLASS_CODE) shouldBe false
+        teacher.ownsClass(ClassCode("nonexistent-class-code")) shouldBe false
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
`TeacherPrefsPost` mutated classes using attacker-controlled ids without checking that the requesting teacher owns the target class — an IDOR allowing a teacher to:
- remove **any** student from their class (by `userId`),
- delete **any** class (by class code), and
- make **another teacher's** class active.

## Fix
Add `User.ownsClass(classCode)` (a valid class whose teacher id matches the user) and enforce it in `REMOVE_FROM_CLASS`, `DELETE_CLASS`, and `updateActiveClass`, throwing `InvalidRequestException` for non-owners (the codebase's standard authz-failure path). Disabling the active class (student-mode toggle) and student self-withdrawal remain allowed. Also covers finding #16 (REMOVE_FROM_CLASS now requires the student to be in the teacher's class).

## Testing
- New DB-backed `ownsClass` tests in `ClassManagementTest` (TDD): own class → true, another teacher's class → false, disabled/nonexistent → false.
- Full `readingbat-core` suite green locally; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)