### PR TITLE
Rotate browser session on login to prevent session fixation

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
@@ -19,7 +19,9 @@ package com.readingbat.server.routes
 
 import com.pambrose.common.email.Email
 import com.pambrose.common.exposed.readonlyTx
+import com.pambrose.common.util.randomId
 import com.readingbat.common.AuthName
+import com.readingbat.common.BrowserSession
 import com.readingbat.common.Endpoints.OAUTH_CALLBACK_GITHUB_ENDPOINT
 import com.readingbat.common.Endpoints.OAUTH_CALLBACK_GOOGLE_ENDPOINT
 import com.readingbat.common.Endpoints.OAUTH_LOGIN_GITHUB_ENDPOINT
@@ -193,10 +195,22 @@ private suspend fun RoutingContext.completeOAuthLogin(
   avatarUrl: String?,
 ) {
   val user = findOrCreateOAuthUser(provider, providerId, email, name, avatarUrl)
-  call.sessions.set(UserPrincipal(userId = user.userId))
+  establishAuthenticatedSession(user.userId)
   val returnUrl = safeRedirectPath(call.sessions.get<OAuthReturnUrl>()?.url ?: "/")
   call.sessions.clear<OAuthReturnUrl>()
   call.respondRedirect(returnUrl)
+}
+
+/**
+ * Establishes the authenticated session after a successful login.
+ *
+ * Rotates the anonymous browser session to a fresh id before setting the principal, so any
+ * pre-login browser-session id (which an attacker may have fixed in the victim's browser) is
+ * discarded — closing the session-fixation vector.
+ */
+internal fun RoutingContext.establishAuthenticatedSession(userId: String) {
+  call.sessions.set(BrowserSession(id = randomId(15)))
+  call.sessions.set(UserPrincipal(userId = userId))
 }
 
 private fun findOrCreateOAuthUser(

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthSessionRotationTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthSessionRotationTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.routes
+
+import com.readingbat.common.AuthName.AUTH_COOKIE
+import com.readingbat.common.BrowserSession
+import com.readingbat.common.UserPrincipal
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.server.application.install
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.testApplication
+
+private const val SESSION_COOKIE = "readingbat_session_id"
+private const val SEED_ID = "seed-fixed-session-id"
+
+private fun HttpResponse.cookiePair(name: String): String? =
+  (headers.getAll("Set-Cookie") ?: emptyList())
+    .firstOrNull { it.startsWith("$name=") }
+    ?.substringBefore(";")
+
+/**
+ * Tests that logging in rotates the anonymous browser session, preventing session fixation: a
+ * pre-login (possibly attacker-supplied) browser-session id must be replaced with a fresh one, and
+ * the authentication principal must be issued.
+ */
+class OAuthSessionRotationTest : StringSpec() {
+  init {
+    "establishAuthenticatedSession rotates the browser session id and sets the principal" {
+      testApplication {
+        install(Sessions) {
+          cookie<BrowserSession>(SESSION_COOKIE)
+          cookie<UserPrincipal>(AUTH_COOKIE)
+        }
+        routing {
+          get("/seed") {
+            call.sessions.set(BrowserSession(id = SEED_ID))
+            call.respondText("seeded")
+          }
+          get("/sim-login") {
+            establishAuthenticatedSession("user-1")
+            call.respondText("ok")
+          }
+        }
+
+        // Establish a known (attacker-fixed) browser session, then log in carrying it.
+        val seeded = client.get("/seed").cookiePair(SESSION_COOKIE)
+        seeded.shouldNotBeNull()
+
+        val response = client.get("/sim-login") { header("Cookie", seeded!!) }
+        val setCookies = response.headers.getAll("Set-Cookie") ?: emptyList()
+
+        // Login must issue a fresh browser session cookie that no longer carries the fixed id.
+        val rotated = setCookies.firstOrNull { it.startsWith("$SESSION_COOKIE=") }
+        rotated.shouldNotBeNull()
+        rotated!! shouldNotContain SEED_ID
+        // The authentication principal cookie must be set.
+        setCookies.any { it.startsWith("$AUTH_COOKIE=") } shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`completeOAuthLogin` set the authentication principal but left the anonymous browser-session id unchanged across the privilege change, so a pre-login id an attacker fixed in the victim's browser survived login (session fixation).

## Fix
Extract `establishAuthenticatedSession`, which rotates the browser session to a fresh random id **before** setting the principal.

## Testing
Integration test (TDD): seed a known browser session, log in carrying it, and assert login reissues a *different* browser-session cookie and sets the auth principal. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)