### PR TITLE
Require a verified email for Google OAuth login

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
@@ -77,14 +77,18 @@ private data class GitHubEmail(
 )
 
 @Serializable
-private data class GoogleUser(
+internal data class GoogleUser(
   val id: String = "",
   val name: String? = null,
   val email: String? = null,
+  @SerialName("verified_email") val verifiedEmail: Boolean = false,
   @SerialName("given_name") val givenName: String? = null,
   @SerialName("family_name") val familyName: String? = null,
   val picture: String? = null,
 )
+
+/** Returns the Google account email only if it is present and Google reports it as verified. */
+internal fun GoogleUser.verifiedEmailOrNull(): String? = email?.takeIf { it.isNotBlank() && verifiedEmail }
 
 private val json = Json { ignoreUnknownKeys = true }
 
@@ -170,7 +174,14 @@ fun Routing.oauthRoutes() {
           }
         val googleUser = json.decodeFromString<GoogleUser>(userResponse.body<String>())
 
-        val email = googleUser.email ?: ""
+        // Reject logins without a Google-verified email to prevent account takeover via an
+        // unverified address that matches an existing ReadingBat user.
+        val email =
+          googleUser.verifiedEmailOrNull() ?: run {
+            logger.warn { "Google OAuth rejected: unverified or missing email for providerId=${googleUser.id}" }
+            call.respondRedirect("/")
+            return@get
+          }
         val name = googleUser.name ?: "${googleUser.givenName ?: ""} ${googleUser.familyName ?: ""}".trim()
         val providerId = googleUser.id
         val avatarUrl = googleUser.picture

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthGoogleEmailTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthGoogleEmailTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.routes
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests that Google OAuth only accepts a verified email. Google's userinfo response includes a
+ * `verified_email` flag; accepting an unverified email would let an attacker register a Google
+ * account with someone else's email address and take over the matching ReadingBat account.
+ */
+class OAuthGoogleEmailTest : StringSpec() {
+  init {
+    "verifiedEmailOrNull returns the email when it is present and verified" {
+      GoogleUser(email = "alice@example.com", verifiedEmail = true).verifiedEmailOrNull() shouldBe
+        "alice@example.com"
+    }
+
+    "verifiedEmailOrNull returns null when the email is not verified" {
+      GoogleUser(email = "alice@example.com", verifiedEmail = false).verifiedEmailOrNull() shouldBe null
+    }
+
+    "verifiedEmailOrNull returns null when the email is missing" {
+      GoogleUser(email = null, verifiedEmail = true).verifiedEmailOrNull() shouldBe null
+    }
+
+    "verifiedEmailOrNull returns null when the email is blank" {
+      GoogleUser(email = "   ", verifiedEmail = true).verifiedEmailOrNull() shouldBe null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The Google callback accepted whatever email userinfo returned, ignoring `verified_email`, and auto-linked it to any existing user with a matching address — enabling account takeover via an unverified victim email.

## Fix
Add the `verified_email` field to `GoogleUser` and a `verifiedEmailOrNull` helper; reject the login (redirect home, log a warning) when the email is missing, blank, or unverified.

## Testing
Unit tests (TDD) for `verifiedEmailOrNull`: verified/unverified/missing/blank. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)