### PR TITLE
Reject GitHub OAuth logins without a verified email

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
@@ -70,11 +70,21 @@ private data class GitHubUser(
 )
 
 @Serializable
-private data class GitHubEmail(
+internal data class GitHubEmail(
   val email: String,
   val primary: Boolean = false,
   val verified: Boolean = false,
 )
+
+/**
+ * Resolves a usable GitHub email: the public profile email if set, otherwise the primary verified
+ * address, otherwise any verified address. Returns null when none is available so the caller can
+ * reject the login instead of creating an account with a blank email.
+ */
+internal fun resolveGitHubEmail(profileEmail: String?, emails: List<GitHubEmail>): String? =
+  profileEmail?.takeIf { it.isNotBlank() }
+    ?: emails.firstOrNull { it.primary && it.verified }?.email
+    ?: emails.firstOrNull { it.verified }?.email
 
 @Serializable
 private data class GoogleUser(
@@ -123,17 +133,24 @@ fun Routing.oauthRoutes() {
           }
         val ghUser = json.decodeFromString<GitHubUser>(userResponse.body<String>())
 
-        // Fetch primary email (handles private emails)
-        val email =
-          ghUser.email ?: run {
+        // Fetch the verified emails only when the profile email is missing (handles private emails).
+        val emails =
+          if (ghUser.email.isNullOrBlank()) {
             val emailsResponse =
               ConfigureOAuth.httpClient.get("https://api.github.com/user/emails") {
                 bearerAuth(accessToken)
               }
-            val emails = json.decodeFromString<List<GitHubEmail>>(emailsResponse.body<String>())
-            emails.firstOrNull { it.primary && it.verified }?.email
-              ?: emails.firstOrNull { it.verified }?.email
-              ?: ""
+            json.decodeFromString<List<GitHubEmail>>(emailsResponse.body<String>())
+          } else {
+            emptyList()
+          }
+
+        // Reject the login rather than create an account with a blank email.
+        val email =
+          resolveGitHubEmail(ghUser.email, emails) ?: run {
+            logger.warn { "GitHub OAuth rejected: no verified email for login=${ghUser.login}" }
+            call.respondRedirect("/")
+            return@get
           }
 
         val name = ghUser.name ?: ghUser.login

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthGitHubEmailTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthGitHubEmailTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.routes
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for GitHub OAuth email resolution. Previously, when no usable email was found the callback
+ * fell back to an empty string and created a user with a blank email; this verifies that case now
+ * resolves to null (so the login is rejected) and that only verified emails are accepted.
+ */
+class OAuthGitHubEmailTest : StringSpec() {
+  init {
+    "resolveGitHubEmail uses a present profile email" {
+      resolveGitHubEmail("alice@example.com", emptyList()) shouldBe "alice@example.com"
+    }
+
+    "resolveGitHubEmail prefers a primary verified email when the profile email is blank" {
+      val emails =
+        listOf(
+          GitHubEmail("secondary@example.com", primary = false, verified = true),
+          GitHubEmail("primary@example.com", primary = true, verified = true),
+        )
+      resolveGitHubEmail(null, emails) shouldBe "primary@example.com"
+    }
+
+    "resolveGitHubEmail falls back to any verified email" {
+      val emails =
+        listOf(
+          GitHubEmail("unverified@example.com", primary = true, verified = false),
+          GitHubEmail("verified@example.com", primary = false, verified = true),
+        )
+      resolveGitHubEmail(null, emails) shouldBe "verified@example.com"
+    }
+
+    "resolveGitHubEmail returns null when only unverified emails exist" {
+      resolveGitHubEmail(null, listOf(GitHubEmail("x@example.com", primary = true, verified = false))) shouldBe null
+    }
+
+    "resolveGitHubEmail returns null when there is no email at all" {
+      resolveGitHubEmail(null, emptyList()) shouldBe null
+      resolveGitHubEmail("   ", emptyList()) shouldBe null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
When GitHub returned no usable email, the callback fell back to an empty string and created (or matched) a user with a blank email address.

## Fix
Extract `resolveGitHubEmail`, which returns the profile email, else a primary verified address, else any verified address, or null when none exists. The callback now rejects the login (redirect home, log a warning) instead of proceeding with a blank email.

## Testing
Unit tests (TDD) for `resolveGitHubEmail`: profile email / primary-verified / any-verified / only-unverified / none. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)