### PR TITLE
Mask secrets instead of revealing 75% in logs

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
@@ -21,6 +21,18 @@ import com.pambrose.common.util.obfuscate
 import com.readingbat.common.Constants.UNASSIGNED
 
 /**
+ * Masks a secret for safe display in logs and the admin config page, revealing at most the last
+ * four characters (and only for sufficiently long values). Replaces `obfuscate(4)`, which left
+ * ~75% of the secret visible.
+ */
+internal fun String.maskSecret(): String =
+  when {
+    isBlank() -> this
+    length < 12 -> "****"
+    else -> "****" + takeLast(4)
+  }
+
+/**
  * Environment variables that can override HOCON [Property] values.
  *
  * Each entry corresponds to a system environment variable. Sensitive values (API keys, passwords,
@@ -35,26 +47,26 @@ enum class EnvVar(val maskFunc: EnvVar.() -> String = { getEnv(UNASSIGNED) }) {
   CLOUD_SQL_CONNECTION_NAME,
   FILTER_LOG,
   GITHUB_OAUTH_CLIENT_ID,
-  GITHUB_OAUTH_CLIENT_SECRET({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  GITHUB_OAUTH_CLIENT_SECRET({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   GOOGLE_OAUTH_CLIENT_ID,
-  GOOGLE_OAUTH_CLIENT_SECRET({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  GOOGLE_OAUTH_CLIENT_SECRET({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   PAPERTRAIL_PORT,
-  IPGEOLOCATION_KEY({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  IPGEOLOCATION_KEY({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   SCRIPT_CLASSPATH,
   OAUTH_CALLBACK_URL_PREFIX,
-  RESEND_API_KEY({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  RESEND_API_KEY({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   RESEND_SENDER_EMAIL,
   REDIRECT_HOSTNAME,
   JAVA_TOOL_OPTIONS,
   DBMS_DRIVER_CLASSNAME,
-  DBMS_URL({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  DBMS_URL({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   DBMS_USERNAME,
   DBMS_PASSWORD({ getEnvOrNull()?.obfuscate(1) ?: UNASSIGNED }),
   FORWARDED_ENABLED,
   XFORWARDED_ENABLED,
   RATE_LIMIT_COUNT,
   RATE_LIMIT_SECS,
-  SESSION_SECRET({ getEnvOrNull()?.obfuscate(4) ?: UNASSIGNED }),
+  SESSION_SECRET({ getEnvOrNull()?.maskSecret() ?: UNASSIGNED }),
   ;
 
   /** Returns true if this environment variable is set. */

--- a/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/Property.kt
@@ -221,7 +221,7 @@ sealed class Property(
     Property(
       propertyValue = "$READINGBAT.$SITE.resendApiKey",
       initFunc = { setProperty(EnvVar.RESEND_API_KEY.getEnv(configValue(it, ""))) },
-      maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
+      maskFunc = { getPropertyOrNull(false)?.maskSecret() ?: UNASSIGNED },
     )
 
   object RESEND_SENDER_EMAIL :
@@ -414,7 +414,7 @@ sealed class Property(
     Property(
       propertyValue = "$READINGBAT.$SITE.githubOAuthClientSecret",
       initFunc = { setProperty(EnvVar.GITHUB_OAUTH_CLIENT_SECRET.getEnv(configValue(it, ""))) },
-      maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
+      maskFunc = { getPropertyOrNull(false)?.maskSecret() ?: UNASSIGNED },
     )
 
   object GOOGLE_OAUTH_CLIENT_ID :
@@ -427,7 +427,7 @@ sealed class Property(
     Property(
       propertyValue = "$READINGBAT.$SITE.googleOAuthClientSecret",
       initFunc = { setProperty(EnvVar.GOOGLE_OAUTH_CLIENT_SECRET.getEnv(configValue(it, ""))) },
-      maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
+      maskFunc = { getPropertyOrNull(false)?.maskSecret() ?: UNASSIGNED },
     )
 
   /** Secret used to sign and encrypt session cookies. Required in production; see ConfigureCookies. */
@@ -435,7 +435,7 @@ sealed class Property(
     Property(
       propertyValue = "$READINGBAT.$SITE.sessionSecret",
       initFunc = { setProperty(EnvVar.SESSION_SECRET.getEnv(configValue(it, ""))) },
-      maskFunc = { getPropertyOrNull(false)?.obfuscate(4) ?: UNASSIGNED },
+      maskFunc = { getPropertyOrNull(false)?.maskSecret() ?: UNASSIGNED },
     )
 
   companion object {

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/MaskSecretTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/MaskSecretTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.common
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * Tests for [maskSecret], the replacement for `obfuscate(4)`, which previously left ~75% of every
+ * secret visible in logs and the admin config page. A mask must reveal at most the last few
+ * characters of a secret.
+ */
+class MaskSecretTest : StringSpec() {
+  init {
+    "maskSecret leaves a blank value unchanged" {
+      "".maskSecret() shouldBe ""
+    }
+
+    "maskSecret fully masks short values, revealing nothing" {
+      "shortsecret".maskSecret() shouldBe "****"
+    }
+
+    "maskSecret reveals only the last four characters of a long secret" {
+      "0123456789abcdefABCD".maskSecret() shouldBe "****ABCD"
+    }
+
+    "maskSecret does not reveal the bulk of a secret" {
+      val secret = "super-sensitive-client-secret-value-1234"
+      val masked = secret.maskSecret()
+      masked shouldNotContain "super-sensitive"
+      masked shouldNotContain secret.dropLast(4)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The mask functions used `obfuscate(4)`, which masks only every 4th character and so left ~75% of each secret (OAuth client secrets, API keys, DBMS URL, session secret) visible in logs and the admin config page.

## Fix
Add `String.maskSecret()`, which reveals at most the last four characters (and only for sufficiently long values), and use it in place of `obfuscate(4)` across `EnvVar` and `Property`. `DBMS_PASSWORD` keeps its full mask.

## Testing
Unit tests (TDD): blank / short / long / no-bulk-leak. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)