### PR TITLE
Don't crash startup on a non-numeric integer env var

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/EnvVar.kt
@@ -19,6 +19,21 @@ package com.readingbat.common
 
 import com.pambrose.common.util.obfuscate
 import com.readingbat.common.Constants.UNASSIGNED
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val envVarLogger = KotlinLogging.logger {}
+
+/**
+ * Parses an environment variable [raw] value as an Int, falling back to [default] when it is unset
+ * or not a valid integer. A malformed value is logged and ignored rather than crashing startup
+ * (the previous `toInt()` threw `NumberFormatException`).
+ */
+internal fun parseIntEnv(name: String, raw: String?, default: Int): Int {
+  if (raw == null) return default
+  return raw.toIntOrNull() ?: default.also {
+    envVarLogger.warn { "Invalid integer for env var $name: '$raw'; using default $default" }
+  }
+}
 
 /**
  * Masks a secret for safe display in logs and the admin config page, revealing at most the last
@@ -81,9 +96,9 @@ enum class EnvVar(val maskFunc: EnvVar.() -> String = { getEnv(UNASSIGNED) }) {
   /** Returns the environment variable value as a Boolean, or [default] if not set. */
   fun getEnv(default: Boolean) = System.getenv(name)?.toBoolean() ?: default
 
-  /** Returns the environment variable value as an Int, or [default] if not set. */
+  /** Returns the environment variable value as an Int, or [default] if unset or not a valid integer. */
   @Suppress("unused")
-  fun getEnv(default: Int) = System.getenv(name)?.toInt() ?: default
+  fun getEnv(default: Int) = parseIntEnv(name, System.getenv(name), default)
 
   /** Returns the environment variable value, throwing an error if not set. */
   fun getRequiredEnv() = getEnvOrNull() ?: error("Missing $name value")

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/EnvVarParseTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/EnvVarParseTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.common
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [parseIntEnv], which backs `EnvVar.getEnv(Int)`. Previously it called `toInt()` and
+ * threw `NumberFormatException` on a non-numeric value, crashing application startup. A malformed
+ * value must now fall back to the default instead of aborting the server.
+ */
+class EnvVarParseTest : StringSpec() {
+  init {
+    "parseIntEnv returns the default when the value is unset" {
+      parseIntEnv("RATE_LIMIT_COUNT", null, 10) shouldBe 10
+    }
+
+    "parseIntEnv parses a valid integer" {
+      parseIntEnv("RATE_LIMIT_COUNT", "42", 10) shouldBe 42
+    }
+
+    "parseIntEnv falls back to the default on a non-numeric value instead of crashing" {
+      parseIntEnv("RATE_LIMIT_COUNT", "not-a-number", 10) shouldBe 10
+    }
+
+    "parseIntEnv falls back to the default on a blank value" {
+      parseIntEnv("RATE_LIMIT_COUNT", "   ", 10) shouldBe 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`EnvVar.getEnv(Int)` called `toInt()`, which throws `NumberFormatException` on a non-numeric value (e.g. `RATE_LIMIT_COUNT=foo`), aborting server startup over a single misconfigured variable.

## Fix
Extract `parseIntEnv`, which uses `toIntOrNull()` and falls back to the default (logging a warning) on a malformed value.

## Testing
Unit tests (TDD): unset / valid / non-numeric / blank. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)