### PR TITLE
Bound answer-check loop by invocation count, not the request

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/posts/ChallengePost.kt
@@ -193,6 +193,16 @@ internal class ChallengeNames(paramMap: Map<String, String>) {
 internal object ChallengePost {
   private val logger = KotlinLogging.logger {}
 
+  /**
+   * Builds the list of user responses for a challenge, one per invocation, bounded by
+   * [invocationCount]. The number of `response*` form params is client-controlled, while a
+   * challenge has a fixed number of invocations; iterating by the request would let an oversized
+   * submission index the answer arrays out of bounds. Extra/non-numeric `response*` params are
+   * ignored and a missing one is treated as an empty (unanswered) response.
+   */
+  internal fun boundedResponses(invocationCount: Int, paramMap: Map<String, String>): List<String> =
+    (0 until invocationCount).map { paramMap[RESP + it]?.trim() ?: "" }
+
   /** Validates user-submitted answers against correct answers and returns JSON results. */
   suspend fun RoutingContext.checkAnswers(content: ReadingBatContent, user: User?) {
     val params = call.receiveParameters()
@@ -200,18 +210,18 @@ internal object ChallengePost {
     val names = ChallengeNames(paramMap)
     val challenge = content.findChallenge(names.languageName, names.groupName, names.challengeName)
     val funcInfo = challenge.functionInfo()
-    val userResponses = params.entries().filter { it.key.startsWith(RESP) }
+    // Bound by the challenge's invocation count, not the client-supplied response* param count.
+    val userResponses = boundedResponses(funcInfo.invocationCount, paramMap)
 
     logger.debug { "Found ${userResponses.size} user responses in $paramMap" }
 
     val results =
-      userResponses.indices.map { i ->
-        val userResponse = paramMap[RESP + i]?.trim() ?: error("Missing user response")
+      userResponses.mapIndexed { i, userResponse ->
         funcInfo.checkResponse(i, userResponse)
       }
 
     if (isDbmsEnabled())
-      saveChallengeAnswers(user, content, names, paramMap, funcInfo, userResponses, results)
+      saveChallengeAnswers(user, content, names, funcInfo, userResponses, results)
 
     val answerMapping =
       buildJsonArray {
@@ -371,18 +381,15 @@ internal object ChallengePost {
     user: User?,
     content: ReadingBatContent,
     names: ChallengeNames,
-    paramMap: Map<String, String>,
     funcInfo: FunctionInfo,
-    userResponses: List<Map.Entry<String, List<String>>>,
+    userResponses: List<String>,
     results: List<ChallengeResults>,
   ) {
-    // Save the last answers given
+    // Save the last answers given (already bounded to the invocation count by boundedResponses).
     val invokeList =
-      userResponses.indices
-        .map { i ->
-          val userResponse = paramMap[RESP + i]?.trim()?.maxLength(256) ?: error("Missing user response")
-          funcInfo.invocations[i] to userResponse
-        }
+      userResponses.mapIndexed { i, userResponse ->
+        funcInfo.invocations[i] to userResponse.maxLength(256)
+      }
 
     val challengeMd5 = names.md5()
     val shouldPublish = user?.shouldPublish() ?: false

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/BoundedResponsesTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/BoundedResponsesTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.posts
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [ChallengePost.boundedResponses]. The answer-check handler previously derived the loop
+ * count from the client-supplied `response*` params and indexed the challenge's fixed-size
+ * invocation/answer arrays directly, so a request with more `response*` params than the challenge
+ * has invocations threw `IndexOutOfBoundsException` (an unauthenticated 500/abuse vector). The loop
+ * must instead be bounded by the challenge's invocation count.
+ */
+class BoundedResponsesTest : StringSpec() {
+  init {
+    "boundedResponses returns one trimmed response per invocation" {
+      ChallengePost.boundedResponses(2, mapOf("response0" to " a ", "response1" to "b")) shouldBe
+        listOf("a", "b")
+    }
+
+    "boundedResponses ignores extra response params instead of throwing" {
+      ChallengePost.boundedResponses(
+        2,
+        mapOf("response0" to "a", "response1" to "b", "response2" to "c", "response3" to "d"),
+      ) shouldBe listOf("a", "b")
+    }
+
+    "boundedResponses treats a missing response as blank (unanswered)" {
+      ChallengePost.boundedResponses(3, mapOf("response0" to "a", "response2" to "c")) shouldBe
+        listOf("a", "", "c")
+    }
+
+    "boundedResponses ignores non-numeric response keys" {
+      ChallengePost.boundedResponses(1, mapOf("response0" to "a", "responseFoo" to "x")) shouldBe
+        listOf("a")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`checkAnswers` and `saveChallengeAnswers` iterated the client-supplied `response*` form params and indexed the challenge's fixed-size invocation/answer arrays directly. A request with more `response*` params than the challenge has invocations threw `IndexOutOfBoundsException` (an unauthenticated 500 / abuse vector).

## Fix
Add `boundedResponses`, which builds exactly `invocationCount` responses (ignoring extra/non-numeric `response*` params, treating a missing one as unanswered), and drive both loops from it.

## Testing
Unit tests (TDD) for bound/trim/missing/extra; `EndpointTest` + `UserAnswersTest` still pass. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)