### PR TITLE
Escape user data in user-prefs onSubmit confirm() handlers

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/UserPrefsPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/UserPrefsPage.kt
@@ -78,6 +78,7 @@ import kotlinx.html.table
 import kotlinx.html.td
 import kotlinx.html.textInput
 import kotlinx.html.tr
+import org.apache.commons.text.StringEscapeUtils.escapeEcmaScript
 
 /**
  * Generates the user preferences page at `/userprefs`.
@@ -89,6 +90,20 @@ import kotlinx.html.tr
 internal object UserPrefsPage {
   private val logger = KotlinLogging.logger {}
   private const val JOIN_CLASS_BUTTON = "JoinClassButton"
+
+  /**
+   * Builds the inline `onSubmit` confirmation for account deletion. The email is user-controlled
+   * and embedded in a single-quoted JS string, so it is escaped with [escapeEcmaScript].
+   */
+  internal fun deleteAccountConfirmJs(email: String): String =
+    "return confirm('Are you sure you want to permanently delete the account for ${escapeEcmaScript(email)} ?')"
+
+  /**
+   * Builds the inline `onSubmit` confirmation for withdrawing from a class. The class display
+   * string includes the teacher-set description, so it is escaped with [escapeEcmaScript].
+   */
+  internal fun withdrawConfirmJs(displayStr: String): String =
+    "return confirm('Are you sure you want to withdraw from class ${escapeEcmaScript(displayStr)}?')"
 
   fun RoutingContext.userPrefsPage(
     content: ReadingBatContent,
@@ -197,7 +212,7 @@ internal object UserPrefsPage {
           form {
             action = USER_PREFS_ENDPOINT
             method = FormMethod.post
-            onSubmit = "return confirm('Are you sure you want to withdraw from class $displayStr?')"
+            onSubmit = withdrawConfirmJs(displayStr)
             submitInput {
               style = "font-size:12px"
               name = PREFS_ACTION_PARAM
@@ -299,7 +314,7 @@ internal object UserPrefsPage {
         form {
           action = USER_PREFS_ENDPOINT
           method = FormMethod.post
-          onSubmit = "return confirm('Are you sure you want to permanently delete the account for $email ?')"
+          onSubmit = deleteAccountConfirmJs(email.toString())
           submitInput {
             style = "font-size:12px"
             name = PREFS_ACTION_PARAM

--- a/readingbat-core/src/test/kotlin/com/readingbat/pages/UserPrefsPageJsTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/pages/UserPrefsPageJsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.pages
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the inline `onSubmit` confirm() handlers on the user prefs page. The user's email and
+ * the enrolled class display string (which includes the teacher-set class description) were
+ * interpolated directly into single-quoted JS strings, so an apostrophe could break out and inject
+ * script. Both must be escaped with escapeEcmaScript.
+ */
+class UserPrefsPageJsTest : StringSpec() {
+  init {
+    "deleteAccountConfirmJs embeds a plain email verbatim" {
+      UserPrefsPage.deleteAccountConfirmJs("user@example.com") shouldBe
+        "return confirm('Are you sure you want to permanently delete the account for user@example.com ?')"
+    }
+
+    "deleteAccountConfirmJs escapes a quote-injection email" {
+      UserPrefsPage.deleteAccountConfirmJs("'); alert(1); ('") shouldBe
+        "return confirm('Are you sure you want to permanently delete the account for \\'); alert(1); (\\' ?')"
+    }
+
+    "withdrawConfirmJs embeds a plain class string verbatim" {
+      UserPrefsPage.withdrawConfirmJs("Intro to Java [abc123]") shouldBe
+        "return confirm('Are you sure you want to withdraw from class Intro to Java [abc123]?')"
+    }
+
+    "withdrawConfirmJs escapes a quote-injection class description" {
+      UserPrefsPage.withdrawConfirmJs("'); alert(document.cookie); ('") shouldBe
+        "return confirm('Are you sure you want to withdraw from class \\'); alert(document.cookie); (\\'?')"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The account-delete and class-withdraw buttons interpolated the user's email and the enrolled-class display string (which includes the **teacher-set** class description) directly into single-quoted JS strings in `onSubmit`, so an apostrophe could break out and inject script — self-XSS for the email and stored XSS for the teacher-controlled description.

## Fix
Extract `deleteAccountConfirmJs` / `withdrawConfirmJs` and escape the interpolated values with `escapeEcmaScript`.

## Testing
Unit tests (TDD): plain values and quote-injection payloads. lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)