### PR TITLE
Fix WebSocket reliability and DSL parser ordering bugs

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/parse/JavaParse.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/parse/JavaParse.kt
@@ -98,12 +98,13 @@ internal object JavaParse {
    * inner expression as an [Invocation].
    */
   fun extractJavaInvocations(code: List<String>, start: Regex, end: Regex): List<Invocation> =
-    prefixes.flatMap { prefix ->
-      code.linesBetween(start, end)
-        .map { it.trimStart() }
-        .filter { it.startsWith("$prefix(") }
-        .map { Invocation(it.extractBalancedContent("$prefix(")) }
-    }
+    code.linesBetween(start, end)
+      .map { it.trimStart() }
+      .mapNotNull { line ->
+        // Detect the prefix per line and keep source-line order, rather than grouping by prefix.
+        val prefix = prefixes.firstOrNull { line.startsWith("$it(") } ?: return@mapNotNull null
+        Invocation(line.extractBalancedContent("$prefix("))
+      }
 
   /**
    * Converts Java challenge source code into an evaluable script.

--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/parse/KotlinParse.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/parse/KotlinParse.kt
@@ -120,11 +120,13 @@ internal object KotlinParse {
   fun convertToKotlinScript(code: List<String>) =
     buildString {
       var insideMain = false
+      var braceDepth = 0
 
       code.forEach { line ->
         when {
-          line.contains(funMainRegex) -> {
+          !insideMain && line.contains(funMainRegex) -> {
             insideMain = true
+            braceDepth = line.netBraceCount()
           }
 
           insideMain && line.trimStart().startsWith(PRINT_PREFIX) -> {
@@ -132,8 +134,14 @@ internal object KotlinParse {
             appendLine("$VAR_NAME.add($expr)")
           }
 
-          insideMain && line.trimStart().startsWith("}") -> {
-            insideMain = false
+          insideMain -> {
+            braceDepth += line.netBraceCount()
+            // Only main's own closing brace (depth back to 0) ends the body; a nested closing
+            // brace stays part of the body so later println calls are still converted.
+            if (braceDepth <= 0)
+              insideMain = false
+            else
+              appendLine(line)
           }
 
           else -> {
@@ -143,4 +151,6 @@ internal object KotlinParse {
       }
       appendLine("")
     }
+
+  private fun String.netBraceCount() = count { it == '{' } - count { it == '}' }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeGroupWs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeGroupWs.kt
@@ -127,15 +127,21 @@ internal object ChallengeGroupWs {
                   var likes = 0
                   var dislikes = 0
 
+                  // Batch the per-invocation history into a single query per enrollee instead of
+                  // two transactions per invocation (historyExists + answerHistory).
+                  val challengeMd5s =
+                    funcInfo.invocations.map { md5Of(languageName, groupName, challengeName, it) }
+
                   for (enrollee in enrollees) {
                     var attempted = 0
                     var numCorrect = 0
 
+                    val historyMap = enrollee.answerHistoryBulk(challengeMd5s)
                     for (invocation in funcInfo.invocations) {
                       val historyMd5 = md5Of(languageName, groupName, challengeName, invocation)
-                      if (enrollee.historyExists(historyMd5, invocation)) {
+                      val history = historyMap[historyMd5]
+                      if (history != null) {
                         attempted++
-                        val history = enrollee.answerHistory(historyMd5, invocation)
                         if (history.correct)
                           numCorrect++
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeWs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeWs.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -88,6 +89,7 @@ internal object ChallengeWs {
     MutableSharedFlow<ChallengeAnswerData>(extraBufferCapacity = FLOW_BUFFER_CAPACITY)
   }
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val slowConsumerTimeout = 5.seconds
   val answerWsConnections: MutableSet<AnswerSessionContext> = synchronizedSet(LinkedHashSet<AnswerSessionContext>())
   var maxAnswerWsConnections = 0
 
@@ -116,7 +118,9 @@ internal object ChallengeWs {
     scope.launch(CoroutineName("pinger")) {
       while (isActive) {
         delay(1.seconds)
-        for (sessionContext in answerWsConnections) {
+        // Iterate a snapshot taken under the set's monitor so a concurrent add/remove can't throw
+        // a ConcurrentModificationException and kill the pinger coroutine.
+        for (sessionContext in answerWsConnections.snapshotUnderMonitor()) {
           if (sessionContext.enabled) {
             runCatching {
               val json = PingMessage(sessionContext.start.elapsedNow().format()).toJson()
@@ -154,12 +158,21 @@ internal object ChallengeWs {
             .onStart { logger.info { "Starting to read challenge ws channel values" } }
             .onCompletion { logger.info { "Finished reading challenge ws channel values" } }
             .collect { data ->
-              answerWsConnections
+              answerWsConnections.snapshotUnderMonitor()
                 .filter { it.targetName == data.target }
-                .forEach {
-                  it.metrics.wsStudentAnswerResponseCount.labels(agentLaunchId())?.inc()
-                  it.wsSession.outgoing.send(Frame.Text(data.jsonArgs))
-                  logger.debug { "Sent $data ${answerWsConnections.size}" }
+                .forEach { ctx ->
+                  // Deliver to each recipient in its own child coroutine so one slow consumer can't
+                  // stall delivery to the others; close a session that stays blocked past the timeout.
+                  scope.launch {
+                    runCatching {
+                      withTimeoutOrNull(slowConsumerTimeout) {
+                        ctx.metrics.wsStudentAnswerResponseCount.labels(agentLaunchId())?.inc()
+                        ctx.wsSession.outgoing.send(Frame.Text(data.jsonArgs))
+                      } ?: ctx.wsSession.close(CloseReason(GOING_AWAY, "Slow consumer"))
+                    }.onFailure { e ->
+                      logger.error { "Exception sending to ws client: ${e.simpleClassName} ${e.message}" }
+                    }
+                  }
                 }
             }
         }.onFailure { e ->

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ClockWs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ClockWs.kt
@@ -74,7 +74,9 @@ internal object ClockWs {
     scope.launch(CoroutineName("clock-pinger")) {
       while (isActive) {
         delay(1.seconds)
-        for (sessionContext in wsConnections) {
+        // Iterate a snapshot under the set's monitor to avoid a ConcurrentModificationException
+        // (from concurrent add/remove) terminating the pinger coroutine.
+        for (sessionContext in wsConnections.snapshotUnderMonitor()) {
           runCatching {
             val elapsed = sessionContext.start.elapsedNow().format()
             val json = PingMessage("$elapsed [${wsConnections.size}/$maxWsConnections]").toJson()

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/WsUtils.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/WsUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.ws
+
+/**
+ * Returns a copy of this set taken while holding its intrinsic monitor, safe to iterate without a
+ * `ConcurrentModificationException` even if other threads/coroutines add or remove entries
+ * afterward. Intended for the `Collections.synchronizedSet` connection sets used by the WebSocket
+ * pingers and dispatcher, whose iterators require external synchronization.
+ */
+internal fun <T> MutableSet<T>.snapshotUnderMonitor(): List<T> = synchronized(this) { toList() }

--- a/readingbat-core/src/test/kotlin/com/readingbat/common/AnswerHistoryBulkEquivalenceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/common/AnswerHistoryBulkEquivalenceTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.common
+
+import com.pambrose.common.email.Email
+import com.pambrose.common.exposed.upsert
+import com.readingbat.server.FullName
+import com.readingbat.server.Invocation
+import com.readingbat.server.UserAnswerHistoryTable
+import com.readingbat.server.userAnswerHistoryIndex
+import com.readingbat.withTestApp
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * Characterizes the equivalence the ChallengeGroupWs N+1 fix relies on: a single
+ * [User.answerHistoryBulk] call returns an entry for exactly the md5s that have stored history
+ * (matching the per-invocation [User.historyExists]), with the same correct/incorrectAttempts as
+ * [User.answerHistory]. This lets the dashboard aggregation use one query per enrollee instead of
+ * two transactions per invocation.
+ */
+class AnswerHistoryBulkEquivalenceTest : StringSpec() {
+  init {
+    "answerHistoryBulk matches per-invocation historyExists/answerHistory" {
+      withTestApp {
+        val user =
+          User.createOAuthUser(
+            name = FullName("Bulk Equivalence User"),
+            emailVal = Email("bulk-equiv@test.com"),
+            provider = OAuthProvider.GITHUB,
+            providerId = "bulk-equiv-001",
+          )
+
+        transaction {
+          with(UserAnswerHistoryTable) {
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+              row[userRef] = user.userDbmsId
+              row[md5] = "md5-a"
+              row[invocation] = "f(1)"
+              row[updated] = nowInstant()
+              row[correct] = true
+              row[incorrectAttempts] = 2
+              row[historyJson] = "[]"
+            }
+            upsert(conflictIndex = userAnswerHistoryIndex) { row ->
+              row[userRef] = user.userDbmsId
+              row[md5] = "md5-b"
+              row[invocation] = "f(2)"
+              row[updated] = nowInstant()
+              row[correct] = false
+              row[incorrectAttempts] = 0
+              row[historyJson] = "[]"
+            }
+          }
+        }
+
+        val bulk = user.answerHistoryBulk(listOf("md5-a", "md5-b", "md5-c"))
+
+        // Present for exactly the md5s with stored history (== historyExists), absent otherwise.
+        bulk.keys shouldBe setOf("md5-a", "md5-b")
+        user.historyExists("md5-a", Invocation("f(1)")) shouldBe true
+        user.historyExists("md5-c", Invocation("f(9)")) shouldBe false
+
+        // Values match the per-invocation answerHistory.
+        bulk.getValue("md5-a").correct shouldBe true
+        bulk.getValue("md5-a").incorrectAttempts shouldBe 2
+        bulk.getValue("md5-b").correct shouldBe false
+        bulk.getValue("md5-a").correct shouldBe user.answerHistory("md5-a", Invocation("f(1)")).correct
+      }
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/dsl/JavaInvocationOrderTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/dsl/JavaInvocationOrderTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.dsl
+
+import com.readingbat.dsl.parse.JavaParse.extractJavaInvocations
+import com.readingbat.dsl.parse.JavaParse.javaEndRegex
+import com.readingbat.dsl.parse.JavaParse.psvmRegex
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests that [extractJavaInvocations] preserves source-line order when a challenge's main mixes
+ * different print prefixes. The previous implementation grouped invocations by prefix, so e.g. all
+ * println(...) calls came before all arrayPrint(...) calls regardless of their position in source —
+ * misaligning the displayed invocations with the computed answers.
+ */
+class JavaInvocationOrderTest : StringSpec() {
+  init {
+    "extractJavaInvocations preserves source-line order across mixed print prefixes" {
+      val code =
+        """
+          public class Test {
+              public static void main(String[] args) {
+                  System.out.println(a(1));
+                  arrayPrint(b(2));
+                  System.out.println(c(3));
+              }
+          }
+        """.trimIndent()
+
+      extractJavaInvocations(code, psvmRegex, javaEndRegex).map { it.toString() } shouldBe
+        listOf("a(1)", "b(2)", "c(3)")
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/dsl/KotlinNestedBraceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/dsl/KotlinNestedBraceTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.dsl
+
+import com.readingbat.dsl.parse.KotlinParse.convertToKotlinScript
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * Tests that [convertToKotlinScript] does not treat the first `}`-prefixed line as the end of
+ * `main`. Previously a nested closing brace (e.g. an `if` block) ended `main` early, so any
+ * `println` after it was left untouched instead of converted to an `answers.add(...)` call.
+ */
+class KotlinNestedBraceTest : StringSpec() {
+  init {
+    "convertToKotlinScript converts println calls after a nested brace block" {
+      val code =
+        """
+          fun main() {
+              if (true) {
+                  println(foo(1))
+              }
+              println(bar(2))
+          }
+        """.trimIndent().lines()
+
+      val script = convertToKotlinScript(code)
+
+      script shouldContain "answers.add(foo(1))"
+      // The println after the nested block must also be converted, not left as a raw println.
+      script shouldContain "answers.add(bar(2))"
+      script shouldNotContain "println(bar(2))"
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ws/WsConnectionSnapshotTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ws/WsConnectionSnapshotTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.ws
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.Collections
+
+/**
+ * Tests for [snapshotUnderMonitor]. The WebSocket pingers and dispatcher iterate a
+ * `Collections.synchronizedSet` of connections while other coroutines concurrently add/remove
+ * entries. Iterating the live set throws `ConcurrentModificationException`, which killed the
+ * pinger coroutine for the process lifetime. Iterating a snapshot taken under the set's monitor
+ * decouples iteration from mutation.
+ */
+class WsConnectionSnapshotTest : StringSpec() {
+  init {
+    "directly iterating a synchronized set throws when modified mid-iteration" {
+      val set = Collections.synchronizedSet(LinkedHashSet<Int>()).apply { addAll(1..5) }
+      shouldThrow<ConcurrentModificationException> {
+        for (x in set) set.add(x + 100)
+      }
+    }
+
+    "iterating a snapshot tolerates mutation of the source set" {
+      val set = Collections.synchronizedSet(LinkedHashSet<Int>()).apply { addAll(1..5) }
+      shouldNotThrowAny {
+        for (x in set.snapshotUnderMonitor()) set.add(x + 100)
+      }
+    }
+
+    "snapshotUnderMonitor returns a decoupled copy" {
+      val set = Collections.synchronizedSet(LinkedHashSet<Int>()).apply { addAll(listOf(1, 2, 3)) }
+      val snapshot = set.snapshotUnderMonitor()
+      set.add(4)
+      set.remove(1)
+      snapshot shouldBe listOf(1, 2, 3)
+    }
+  }
+}


### PR DESCRIPTION
Bundles six findings.

## WebSocket (server/ws)
- **#17/#18** Add `snapshotUnderMonitor()` and use it in the ChallengeWs and ClockWs pingers (and the dispatcher), so iterating the `Collections.synchronizedSet` of connections no longer throws a `ConcurrentModificationException` that killed the pinger coroutine for the process lifetime.
- **#20** Dispatcher delivers to each recipient in its own child coroutine bounded by a 5s timeout, closing slow consumers, so one slow client can no longer stall delivery to everyone.
- **#19** ChallengeGroupWs: replace the per-invocation `historyExists` + `answerHistory` (two transactions per invocation) with a single `answerHistoryBulk` query per enrollee, collapsing the N+1. *(Partial: the Dispatchers.IO offload and per-class like/dislike batching, plus the sibling ClassSummaryWs/StudentSummaryWs, are left as follow-up.)*

## DSL parsers (dsl/parse)
- **#12** `convertToKotlinScript` tracks brace depth so a nested closing brace no longer ends `main` early (leaving later `println` calls unconverted).
- **#13** `extractJavaInvocations` iterates lines once in source order instead of grouping by print prefix, preserving invocation order.

## Tests
Parser fixes, the snapshot helper, and the `answerHistoryBulk` equivalence the N+1 fix relies on. Full suite green; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)