### PR TITLE
Fix dashboard-flow backpressure, dir cache, and geo cache

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/ChallengeGroup.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/ChallengeGroup.kt
@@ -84,11 +84,9 @@ class ChallengeGroup<T : Challenge>(
   // Do not use lazy for groupName because namePrefix is assigned late in the process of includes
   val groupName get() = GroupName("${namePrefix.ifBlank { "" }}${groupNameSuffix.value}")
 
-  private fun dirContentsKey(path: String) = keyOf(DIR_CONTENTS_KEY, md5Of(path))
-
   private fun fetchDirContentsFromDirCache(path: String) =
     if (isContentCachingEnabled()) {
-      dirCache[path]?.toList().apply { logger.debug { """Retrieved "$path" from dir cache""" } }
+      readDirCache(path).apply { logger.debug { """Retrieved "$path" from dir cache""" } }
     } else {
       null
     }
@@ -101,12 +99,8 @@ class ChallengeGroup<T : Challenge>(
         root.organizationDirectoryContents(branchName, path, metrics)
       ).also {
         if (isContentCachingEnabled()) {
-          synchronized(dirCache) {
-            val dirContentsKey = dirContentsKey(path)
-            dirCache.computeIfAbsent(dirContentsKey) { mutableListOf() }
-            dirCache[dirContentsKey]!!.addAll(it)
-            logger.info { "Saved to dir cache: ${path.toDoubleQuoted()}" }
-          }
+          writeDirCache(path, it)
+          logger.info { "Saved to dir cache: ${path.toDoubleQuoted()}" }
         }
       }
 
@@ -278,5 +272,15 @@ class ChallengeGroup<T : Challenge>(
 
   companion object {
     private val logger = KotlinLogging.logger {}
+
+    private fun dirContentsKey(path: String) = keyOf(DIR_CONTENTS_KEY, md5Of(path))
+
+    /** Reads a cached directory listing using the same composite key the write uses. */
+    internal fun readDirCache(path: String): List<String>? = dirCache[dirContentsKey(path)]?.toList()
+
+    /** Overwrites the cached directory listing so repeated loads don't accumulate duplicates. */
+    internal fun writeDirCache(path: String, files: List<String>) {
+      dirCache[dirContentsKey(path)] = files.toMutableList()
+    }
   }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
@@ -27,9 +27,13 @@ import com.readingbat.common.EnvVar
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -137,8 +141,19 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
   companion object {
     private val logger = KotlinLogging.logger {}
     val geoInfoMap = ConcurrentHashMap<String, GeoInfo>()
-    private val mutex = Mutex()
-    private val httpClient = HttpClient(CIO)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Per-IP in-flight lookups: concurrent requests for the same IP share one Deferred.
+    private val inflight = ConcurrentHashMap<String, Deferred<GeoInfo>>()
+    private val httpClient =
+      HttpClient(CIO) {
+        // A hung ipgeolocation.io endpoint must not stall the request-logging path indefinitely.
+        install(HttpTimeout) {
+          requestTimeoutMillis = 10_000
+          connectTimeoutMillis = 5_000
+          socketTimeoutMillis = 10_000
+        }
+      }
 
     private suspend fun callGeoInfoApi(ipAddress: String) =
       withHttpClient(httpClient) {
@@ -161,28 +176,42 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
         }
       }
 
+    /** Resolves geo info from Postgres, else the ipgeolocation.io API (or a failure placeholder), persisting it. */
+    private suspend fun resolveGeoInfo(ipAddress: String): GeoInfo =
+      queryGeoInfo(ipAddress)?.apply {
+        logger.debug { "Postgres GEO info for $ipAddress: ${summary()}" }
+      }
+        ?: runCatching {
+          callGeoInfoApi(ipAddress)
+        }.getOrElse { e ->
+          GeoInfo(true, -1, ipAddress, "")
+            .also {
+              logger.info { "Unable to determine IP geolocation data for ${it.remoteHost} (${e.message})" }
+            }
+        }.also { it.insert() }
+          // Re-read after insert so the cached entry carries the persisted id and
+          // requireDbmsLookUp=false, eliminating the per-request queryGeoInfo SELECT the
+          // request-logging path would otherwise run for every API/failure-sourced entry.
+          .let { built -> queryGeoInfo(ipAddress) ?: built }
+
     /**
-     * Looks up geolocation for [ipAddress], checking the in-memory cache first, then
-     * PostgreSQL, and finally calling the ipgeolocation.io API as a last resort.
+     * Looks up geolocation for [ipAddress], checking the in-memory cache first, then PostgreSQL,
+     * and finally the ipgeolocation.io API as a last resort.
+     *
+     * Concurrent lookups for the same IP share one in-flight request (per-IP coalescing) while
+     * different IPs resolve in parallel, so a slow/hung API call for one IP no longer head-of-line
+     * blocks geo resolution for every other request — unlike the previous single process-wide lock.
      */
     suspend fun lookupGeoInfo(ipAddress: String): GeoInfo =
-      geoInfoMap[ipAddress] ?: mutex.withLock {
-        geoInfoMap.getOrPut(ipAddress) {
-          queryGeoInfo(ipAddress)?.apply {
-            logger.debug { "Postgres GEO info for $ipAddress: ${summary()}" }
+      geoInfoMap[ipAddress] ?: run {
+        val deferred =
+          inflight.computeIfAbsent(ipAddress) {
+            scope.async { resolveGeoInfo(ipAddress).also { geoInfoMap[ipAddress] = it } }
           }
-            ?: runCatching {
-              callGeoInfoApi(ipAddress)
-            }.getOrElse { e ->
-              GeoInfo(true, -1, ipAddress, "")
-                .also {
-                  logger.info { "Unable to determine IP geolocation data for ${it.remoteHost} (${e.message})" }
-                }
-            }.also { it.insert() }
-              // Re-read after insert so the cached entry carries the persisted id and
-              // requireDbmsLookUp=false, eliminating the per-request queryGeoInfo SELECT the
-              // request-logging path would otherwise run for every API/failure-sourced entry.
-              .let { built -> queryGeoInfo(ipAddress) ?: built }
+        try {
+          deferred.await()
+        } finally {
+          inflight.remove(ipAddress, deferred)
         }
       }
   }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/GeoInfo.kt
@@ -179,6 +179,10 @@ class GeoInfo(val requireDbmsLookUp: Boolean, val dbmsId: Long, val remoteHost: 
                   logger.info { "Unable to determine IP geolocation data for ${it.remoteHost} (${e.message})" }
                 }
             }.also { it.insert() }
+              // Re-read after insert so the cached entry carries the persisted id and
+              // requireDbmsLookUp=false, eliminating the per-request queryGeoInfo SELECT the
+              // request-logging path would otherwise run for every API/failure-sourced entry.
+              .let { built -> queryGeoInfo(ipAddress) ?: built }
         }
       }
   }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeWs.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/ChallengeWs.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -67,6 +68,15 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
 /**
+ * Builds a dashboard flow that drops the oldest buffered update on overflow instead of suspending
+ * the producer. The dashboard publish runs inline in the student answer-submit request, so a
+ * slow/absent teacher collector must never apply backpressure to it; a dropped intermediate update
+ * is acceptable since the next update supersedes it.
+ */
+internal fun <T> dashboardFlow(): MutableSharedFlow<T> =
+  MutableSharedFlow(extraBufferCapacity = FLOW_BUFFER_CAPACITY, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+/**
  * WebSocket endpoint for real-time challenge answer updates.
  *
  * Teachers connect to this endpoint to receive live notifications when students
@@ -78,15 +88,10 @@ import kotlin.time.TimeSource
 internal object ChallengeWs {
   private val logger = KotlinLogging.logger {}
   private val clock = TimeSource.Monotonic
-  val singleServerWsFlow by lazy {
-    MutableSharedFlow<ChallengeAnswerData>(extraBufferCapacity = FLOW_BUFFER_CAPACITY)
-  }
-  val multiServerWsWriteFlow by lazy {
-    MutableSharedFlow<ChallengeAnswerData>(extraBufferCapacity = FLOW_BUFFER_CAPACITY)
-  }
-  val multiServerWsReadFlow by lazy {
-    MutableSharedFlow<ChallengeAnswerData>(extraBufferCapacity = FLOW_BUFFER_CAPACITY)
-  }
+
+  val singleServerWsFlow by lazy { dashboardFlow<ChallengeAnswerData>() }
+  val multiServerWsWriteFlow by lazy { dashboardFlow<ChallengeAnswerData>() }
+  val multiServerWsReadFlow by lazy { dashboardFlow<ChallengeAnswerData>() }
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
   val answerWsConnections: MutableSet<AnswerSessionContext> = synchronizedSet(LinkedHashSet<AnswerSessionContext>())
   var maxAnswerWsConnections = 0

--- a/readingbat-core/src/test/kotlin/com/readingbat/dsl/DirCacheTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/dsl/DirCacheTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.dsl
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests the directory-contents cache read/write. Previously the write used a composite key
+ * (`dir-contents|<md5>`) while the read used the raw path, so the read always missed and GitHub was
+ * re-hit on every group load; the write also accumulated via computeIfAbsent+addAll, growing the
+ * shared cache list unbounded across reloads. The read/write must use one consistent key and the
+ * write must overwrite.
+ */
+class DirCacheTest : StringSpec() {
+  init {
+    "readDirCache returns what writeDirCache stored under a consistent key" {
+      ChallengeGroup.writeDirCache("java/Warmup-1", listOf("a.java", "b.java"))
+      ChallengeGroup.readDirCache("java/Warmup-1") shouldBe listOf("a.java", "b.java")
+    }
+
+    "rewriting the dir cache overwrites instead of accumulating duplicates" {
+      ChallengeGroup.writeDirCache("python/Group-2", listOf("a.py"))
+      ChallengeGroup.writeDirCache("python/Group-2", listOf("a.py", "b.py"))
+      ChallengeGroup.readDirCache("python/Group-2") shouldBe listOf("a.py", "b.py")
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/GeoCacheTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/GeoCacheTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server
+
+import com.readingbat.withTestApp
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * Tests that lookupGeoInfo caches an entry that no longer requires a per-request DB lookup.
+ * Previously the API and failure branches cached `GeoInfo(requireDbmsLookUp = true, dbmsId = -1)`,
+ * so the request-logging path re-ran queryGeoInfo against Postgres on every subsequent request for
+ * that IP. After inserting, the entry must be re-read so the cached value carries the persisted id
+ * and requireDbmsLookUp = false.
+ */
+class GeoCacheTest : StringSpec() {
+  init {
+    "lookupGeoInfo caches an entry that no longer requires a DB lookup" {
+      withTestApp {
+        val ip = "198.51.100.77"
+        // Force the API/failure branch by clearing any cached or persisted entry for this IP.
+        GeoInfo.geoInfoMap.remove(ip)
+        transaction { GeoInfosTable.deleteWhere { GeoInfosTable.ip eq ip } }
+
+        val geo = GeoInfo.lookupGeoInfo(ip)
+
+        geo.requireDbmsLookUp shouldBe false
+        geo.dbmsId shouldBeGreaterThan 0
+        GeoInfo.geoInfoMap[ip]?.requireDbmsLookUp shouldBe false
+      }
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/GeoCacheTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/GeoCacheTest.kt
@@ -19,8 +19,12 @@ package com.readingbat.server
 
 import com.readingbat.withTestApp
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -45,6 +49,21 @@ class GeoCacheTest : StringSpec() {
 
         geo.requireDbmsLookUp shouldBe false
         geo.dbmsId shouldBeGreaterThan 0
+        GeoInfo.geoInfoMap[ip]?.requireDbmsLookUp shouldBe false
+      }
+    }
+
+    "concurrent lookups for the same IP coalesce into one consistent result" {
+      withTestApp {
+        val ip = "203.0.113.55"
+        GeoInfo.geoInfoMap.remove(ip)
+        transaction { GeoInfosTable.deleteWhere { GeoInfosTable.ip eq ip } }
+
+        val results = coroutineScope { (1..50).map { async { GeoInfo.lookupGeoInfo(ip) } }.awaitAll() }
+
+        // All concurrent lookups resolve to the same persisted entry without deadlock or error.
+        results.map { it.dbmsId }.toSet() shouldHaveSize 1
+        results.all { !it.requireDbmsLookUp } shouldBe true
         GeoInfo.geoInfoMap[ip]?.requireDbmsLookUp shouldBe false
       }
     }

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/ws/DashboardFlowTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/ws/DashboardFlowTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.ws
+
+import com.readingbat.common.Constants.FLOW_BUFFER_CAPACITY
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests that the dashboard flows never apply backpressure to the producer. The dashboard publish
+ * runs inline in the student answer-submit request coroutine; with the default SUSPEND overflow a
+ * full buffer (no/slow teacher collector) would suspend `emit` and slow student submissions. A
+ * DROP_OLDEST flow self-evicts so the producer never blocks.
+ */
+class DashboardFlowTest : StringSpec() {
+  init {
+    "dashboardFlow does not suspend the producer when nothing drains it" {
+      val flow = dashboardFlow<Int>()
+      shouldNotThrowAny {
+        runBlocking {
+          // With SUSPEND this blocks once the buffer fills (no collector) and times out; with
+          // DROP_OLDEST every emit returns immediately.
+          withTimeout(5.seconds) {
+            repeat(FLOW_BUFFER_CAPACITY + 500) { flow.emit(it) }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bundles four findings.

- **#15** Build the dashboard flows with `onBufferOverflow = DROP_OLDEST` via a `dashboardFlow()` factory, so a slow/absent teacher collector can't suspend the student answer-submit request that publishes inline.
- **#26** Read and write the directory-contents cache under one consistent composite key and overwrite on write — fixing the permanent cache miss (read used the raw path, write a composite key) and the unbounded duplicate accumulation from `computeIfAbsent`+`addAll`.
- **#21** After `insert()`, re-read via `queryGeoInfo` so a cached entry carries the persisted id and `requireDbmsLookUp=false`, eliminating the per-request `queryGeoInfo` SELECT in the request-logging path.
- **#22** Replace the process-wide geo-lookup `Mutex` with per-IP request coalescing (`ConcurrentHashMap<String, Deferred<GeoInfo>>` on a Dispatchers.IO scope) so a slow/hung API call for one IP no longer head-of-line blocks every other request; add an `HttpTimeout`.

## Tests
TDD tests for each (flow backpressure, dir-cache round-trip/overwrite, geo cache requireDbmsLookUp, geo coalescing). Full suite green; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)