### PR TITLE
Fix enrollment rollback desync, OAuth link race, and cache lock

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/common/User.kt
@@ -278,12 +278,13 @@ class User {
       }
     }
 
+  // Only issues the UPDATE; the in-memory field is assigned by the caller after the surrounding
+  // transaction commits, so a rollback can't leave the object out of sync with the database.
   private fun assignEnrolledClassCode(classCode: ClassCode) =
     with(UsersTable) {
       update({ id eq userDbmsId }) { row ->
         row[updated] = nowInstant()
         row[enrolledClassCode] = classCode.classCode
-        this@User.enrolledClassCode = classCode
       }
     }
 
@@ -428,6 +429,7 @@ class User {
           assignEnrolledClassCode(classCode)
           classCode.addEnrollee(this@User)
         }
+        enrolledClassCode = classCode
       }
     }
   }
@@ -444,6 +446,7 @@ class User {
       if (enrolled)
         classCode.removeEnrollee(this@User)
     }
+    enrolledClassCode = DISABLED_CLASS_CODE
   }
 
   fun unenrollEnrolleesClassCode(classCode: ClassCode, enrollees: List<User>) {

--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/challenge/Challenge.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/challenge/Challenge.kt
@@ -153,25 +153,27 @@ sealed class Challenge(
    */
   fun functionInfo() =
     if (repo.remote) {
-      content.functionInfoMap
-        .computeIfAbsent(challengeId) {
-          val timer = metrics.challengeRemoteReadDuration.labels(agentLaunchId()).startTimer()
-          val code =
-            fetchSourceCodeFromCache() ?: try {
-              val path = pathOf((repo as AbstractRepo).rawSourcePrefix, branchName, srcPath, fqName)
-              val (text, dur) = measureTimedValue { URL(path).readText() }
-              logger.debug { """Fetched "${pathOf(groupName, fileName)}" in: $dur from: $path""" }
+      // Compute outside computeIfAbsent's bin lock: the blocking network fetch + script eval must
+      // not hold the ConcurrentHashMap lock. A rare race may compute twice, but putIfAbsent keeps one.
+      content.functionInfoMap[challengeId] ?: run {
+        val timer = metrics.challengeRemoteReadDuration.labels(agentLaunchId()).startTimer()
+        val code =
+          fetchSourceCodeFromCache() ?: try {
+            val path = pathOf((repo as AbstractRepo).rawSourcePrefix, branchName, srcPath, fqName)
+            val (text, dur) = measureTimedValue { URL(path).readText() }
+            logger.debug { """Fetched "${pathOf(groupName, fileName)}" in: $dur from: $path""" }
 
-              if (isContentCachingEnabled()) {
-                sourceCache[sourceCodeKey] = text
-                logger.debug { """Saved "${pathOf(groupName, fileName)}" to content cache""" }
-              }
-              text
-            } finally {
-              timer.observeDuration()
+            if (isContentCachingEnabled()) {
+              sourceCache[sourceCodeKey] = text
+              logger.debug { """Saved "${pathOf(groupName, fileName)}" to content cache""" }
             }
-          measureParsing(code)
-        }
+            text
+          } finally {
+            timer.observeDuration()
+          }
+        val funcInfo = measureParsing(code)
+        content.functionInfoMap.putIfAbsent(challengeId, funcInfo) ?: funcInfo
+      }
     } else {
       fun parseCode(): FunctionInfo {
         val fs = repo as FileSystemSource
@@ -181,7 +183,10 @@ sealed class Challenge(
       }
 
       if (content.cacheChallenges)
-        content.functionInfoMap.computeIfAbsent(challengeId) { parseCode() }
+        content.functionInfoMap[challengeId] ?: run {
+          val funcInfo = parseCode()
+          content.functionInfoMap.putIfAbsent(challengeId, funcInfo) ?: funcInfo
+        }
       else
         parseCode()
     }

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/routes/OAuthRoutes.kt
@@ -19,6 +19,7 @@ package com.readingbat.server.routes
 
 import com.pambrose.common.email.Email
 import com.pambrose.common.exposed.readonlyTx
+import com.pambrose.common.exposed.upsert
 import com.pambrose.common.util.randomId
 import com.readingbat.common.AuthName
 import com.readingbat.common.BrowserSession
@@ -37,6 +38,7 @@ import com.readingbat.server.FullName
 import com.readingbat.server.OAuthLinksTable
 import com.readingbat.server.ServerUtils.safeRedirectPath
 import com.readingbat.server.UsersTable
+import com.readingbat.server.oauthLinksProviderIndex
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
@@ -57,7 +59,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -241,7 +242,7 @@ internal fun RoutingContext.establishAuthenticatedSession(userId: String) {
   call.sessions.set(UserPrincipal(userId = userId))
 }
 
-private fun findOrCreateOAuthUser(
+internal fun findOrCreateOAuthUser(
   provider: OAuthProvider,
   providerId: String,
   email: Email,
@@ -307,9 +308,11 @@ private fun findOrCreateOAuthUser(
       // This is safe because both GitHub and Google only return verified emails.
       oauthLogger.info { "OAuth login: auto-linking $provider to existing user ${existingUser.email}" }
       transaction {
-        // Link OAuth provider to existing user
+        // Link OAuth provider to existing user. Upsert against the (provider, providerId) unique
+        // index so concurrent first-login callbacks for the same provider account converge to one
+        // link (same userRef) instead of throwing a duplicate-key exception.
         with(OAuthLinksTable) {
-          insert { row ->
+          upsert(conflictIndex = oauthLinksProviderIndex) { row ->
             row[userRef] = existingUser.userDbmsId
             row[OAuthLinksTable.provider] = provider.providerName
             row[OAuthLinksTable.providerId] = providerId

--- a/readingbat-core/src/test/kotlin/com/readingbat/dsl/ChallengeFunctionInfoMemoTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/dsl/ChallengeFunctionInfoMemoTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.dsl
+
+import com.readingbat.TestData
+import com.readingbat.kotest.TestSupport.challengeByName
+import com.readingbat.kotest.TestSupport.initTestProperties
+import com.readingbat.kotest.TestSupport.javaGroup
+import com.readingbat.kotest.TestSupport.testModule
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.ktor.server.testing.testApplication
+
+/**
+ * Guards that functionInfo() still memoizes its result after the #29 refactor that moved the
+ * blocking fetch + script eval out of `ConcurrentHashMap.computeIfAbsent` to a double-checked
+ * get/putIfAbsent: repeated calls must return the same cached instance.
+ */
+class ChallengeFunctionInfoMemoTest : StringSpec() {
+  init {
+    "functionInfo returns the same cached instance on repeated calls" {
+      initTestProperties()
+      testApplication {
+        val testContent = TestData.readTestContent()
+        application { testModule(testContent) }
+
+        val challenge = testContent.javaGroup(TestData.GROUP_NAME).challengeByName("StringArrayTest1")
+        challenge.functionInfo() shouldBeSameInstanceAs challenge.functionInfo()
+      }
+    }
+  }
+}

--- a/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthFindOrCreateRaceTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/server/routes/OAuthFindOrCreateRaceTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.readingbat.server.routes
+
+import com.pambrose.common.email.Email
+import com.pambrose.common.exposed.readonlyTx
+import com.readingbat.common.OAuthProvider
+import com.readingbat.common.User
+import com.readingbat.server.FullName
+import com.readingbat.server.OAuthLinksTable
+import com.readingbat.withTestApp
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+
+/**
+ * Tests that concurrent OAuth callbacks for the same provider account don't race into a duplicate
+ * link. The find-or-create flow checks "does a link exist?" and inserts in separate transactions,
+ * so two simultaneous first-login callbacks (e.g. a double-click) could both fall through to the
+ * insert. The auto-link upsert against the (provider, providerId) unique index makes that converge
+ * to a single link and user instead of throwing a duplicate-key exception.
+ */
+class OAuthFindOrCreateRaceTest : StringSpec() {
+  init {
+    "concurrent OAuth callbacks for the same provider id converge to one link and user" {
+      withTestApp {
+        val email = Email("oauth-race@test.com")
+        val existing = User.createOAuthUser(FullName("Race User"), email, OAuthProvider.GOOGLE, "google-race-001")
+
+        val users =
+          coroutineScope {
+            (1..20).map {
+              async(Dispatchers.IO) {
+                findOrCreateOAuthUser(OAuthProvider.GITHUB, "github-race-001", email, FullName("Race User"))
+              }
+            }.awaitAll()
+          }
+
+        // All concurrent callbacks resolve to the same (existing) user.
+        users.map { it.userId }.toSet() shouldHaveSize 1
+        users.first().userId shouldBe existing.userId
+
+        // Exactly one GitHub link exists despite the concurrent inserts.
+        val linkCount =
+          readonlyTx {
+            OAuthLinksTable
+              .selectAll()
+              .where {
+                (OAuthLinksTable.provider eq OAuthProvider.GITHUB.providerName) and
+                  (OAuthLinksTable.providerId eq "github-race-001")
+              }
+              .count()
+          }
+        linkCount shouldBe 1L
+      }
+    }
+  }
+}


### PR DESCRIPTION
Three low-severity correctness/concurrency fixes.

- **#27** `User.assignEnrolledClassCode` only issues the UPDATE; the in-memory `enrolledClassCode` is assigned after the transaction commits in `enrollInClass`/`withdrawFromClass`, so a rollback no longer leaves the object out of sync with the database.
- **#28** `findOrCreateOAuthUser` upserts the existing-user auto-link against the `(provider, providerId)` unique index, so concurrent first-login callbacks converge to one link/user instead of a duplicate-key exception. *(The rarer new-user `createOAuthUser` race is left for the fuller transaction+email-lock fix.)*
- **#29** `Challenge.functionInfo()` uses double-checked `get`/`putIfAbsent` so the blocking network fetch + script eval no longer runs inside the `ConcurrentHashMap` bin lock.

## Tests
New `OAuthFindOrCreateRaceTest` (20 concurrent callbacks → one link, verified RED against the old `insert`) and `ChallengeFunctionInfoMemoTest` (memoization preserved). Full suite green; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)