### PR TITLE
Dedup teacher-id lookups, drop dead repo guard

### DIFF
--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/ContentDsl.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/ContentDsl.kt
@@ -107,8 +107,14 @@ fun readingBatContent(block: ReadingBatContent.() -> Unit) =
 /** Returns true if the server is running in production mode. Accessible from Content.kt DSL files. */
 fun isProduction() = IS_PRODUCTION.getProperty(false)
 
-/** Returns true if the server is running in test mode. Accessible from Content.kt DSL files. */
-fun isTesting() = IS_TESTING.getProperty(false)
+/**
+ * Returns true if the server is running in test mode. Accessible from Content.kt DSL files.
+ *
+ * IS_TESTING is not part of [initProperties] (it is set directly via setProperty in tests and
+ * defaults to false in production), so it is read with errorOnNonInit = false: the single global
+ * init guard can never meaningfully flag this specific property anyway.
+ */
+fun isTesting() = IS_TESTING.getProperty(false, errorOnNonInit = false)
 
 internal fun isDbmsEnabled() = DBMS_ENABLED.getProperty(false)
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/LanguageGroup.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/LanguageGroup.kt
@@ -18,7 +18,6 @@
 package com.readingbat.dsl
 
 import com.pambrose.common.util.ContentRoot
-import com.pambrose.common.util.ContentSource
 import com.pambrose.common.util.asRegex
 import com.pambrose.common.util.decode
 import com.pambrose.common.util.pathOf
@@ -52,15 +51,10 @@ class LanguageGroup<T : Challenge>(
   val challengeGroups = mutableListOf<ChallengeGroup<T>>()
 
   /**
-   * The content source for this language's challenge files. Defaults to the parent
-   * [ReadingBatContent.repo] value. Must be set to a valid source before challenges are loaded.
+   * The content source for this language's challenge files. Inherits the parent
+   * [ReadingBatContent.repo] value unless overridden in the DSL.
    */
   var repo: ContentRoot = content.repo           // Defaults to outer-level value
-    get() =
-      if (field == defaultContentRoot)
-        error("$languageName section is missing a repo value")
-      else
-        field
 
   /** Git branch name for remote content. Defaults to the parent [ReadingBatContent.branchName]. */
   var branchName = content.branchName    // Defaults to outer-level value
@@ -145,18 +139,5 @@ class LanguageGroup<T : Challenge>(
   companion object {
     private val logger = KotlinLogging.logger {}
     private val excludes = Regex("^__.*__.*$")
-
-    internal val defaultContentRoot =
-      object : ContentRoot {
-        override val sourcePrefix = ""
-        override val remote = false
-
-        override fun file(path: String) =
-          object : ContentSource {
-            override val content = ""
-            override val remote = false
-            override val source = ""
-          }
-      }
   }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ClassSummaryPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ClassSummaryPage.kt
@@ -133,13 +133,11 @@ internal object ClassSummaryPage {
         throw InvalidRequestException("Invalid user")
       }
 
-      classCode.fetchClassTeacherId() != user.userId -> {
-        val teacherId = classCode.fetchClassTeacherId()
-        throw InvalidRequestException("User id ${user.userId} does not match class code's teacher id $teacherId")
-      }
-
       else -> {
-        // Do nothing
+        // Look up the teacher id once and reuse it for both the check and the message.
+        val teacherId = classCode.fetchClassTeacherId()
+        if (teacherId != user.userId)
+          throw InvalidRequestException("User id ${user.userId} does not match class code's teacher id $teacherId")
       }
     }
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
@@ -109,14 +109,12 @@ internal object StudentSummaryPage {
         throw InvalidRequestException("Invalid user")
       }
 
-      // classCode != activeClassCode -> throw InvalidRequestException("Class code mismatch")
-      classCode.fetchClassTeacherId() != user.userId -> {
-        val teacherId = classCode.fetchClassTeacherId()
-        throw InvalidRequestException("User id ${user.userId} does not match class code's teacher Id $teacherId")
-      }
-
       else -> {
-        // Do nothing
+        // classCode != activeClassCode -> throw InvalidRequestException("Class code mismatch")
+        // Look up the teacher id once and reuse it for both the check and the message.
+        val teacherId = classCode.fetchClassTeacherId()
+        if (teacherId != user.userId)
+          throw InvalidRequestException("User id ${user.userId} does not match class code's teacher Id $teacherId")
       }
     }
 

--- a/readingbat-core/src/main/kotlin/com/readingbat/server/ws/WsCommon.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/server/ws/WsCommon.kt
@@ -104,13 +104,13 @@ object WsCommon {
         false to "Invalid user id: ${user.userId}"
       }
 
-      classCode.fetchClassTeacherId() != user.userId -> {
-        val teacherId = classCode.fetchClassTeacherId()
-        false to "User id ${user.userId} does not match class code's teacher Id $teacherId"
-      }
-
       else -> {
-        true to ""
+        // Look up the teacher id once and reuse it for both the check and the message.
+        val teacherId = classCode.fetchClassTeacherId()
+        if (teacherId != user.userId)
+          false to "User id ${user.userId} does not match class code's teacher Id $teacherId"
+        else
+          true to ""
       }
     }.also { (valid, msg) -> if (!valid) throw InvalidRequestException(msg) }
 


### PR DESCRIPTION
Four low-severity cleanups.

- **#35 / #43** Look up `fetchClassTeacherId` once per authorization check and reuse it for the comparison and the error message, instead of issuing the DB query twice on the unauthorized path (WsCommon, ClassSummaryPage, StudentSummaryPage).
- **#45** Remove the unreachable `repo` getter guard and the unused `defaultContentRoot` sentinel (the guard could never fire); fix the misleading KDoc.
- **#44 (partial)** Read `IS_TESTING` with `errorOnNonInit = false` since it isn't part of `initProperties()` and the single global init guard can never meaningfully flag it. The full per-property guard rewrite is intentionally **not** done — it would break the test suite and production, and the finding notes no functional bug.

Behavior-preserving (fewer DB calls / dead-code removal / no value change); covered by the existing authz/content tests. Full suite green; lint + detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)