### PR TITLE
Make Challenge.functionInfo() suspend instead of bridging via runBlocking

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ python = "2.7.4"
 resend = "4.13.0"
 serialization = "1.11.0"
 testcontainers = "1.21.4"
-utils = "2.9.1"
+utils = "2.9.2"
 
 [libraries]
 # Serialization

--- a/readingbat-core/src/main/kotlin/com/readingbat/dsl/challenge/Challenge.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/dsl/challenge/Challenge.kt
@@ -56,7 +56,8 @@ import com.readingbat.server.Invocation
 import com.readingbat.server.ScriptPools
 import com.readingbat.utils.toCapitalized
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.URL
 import java.nio.file.Paths
 import kotlin.concurrent.atomics.AtomicInt
@@ -110,7 +111,7 @@ sealed class Challenge(
   private val content get() = challengeGroup.languageGroup.content
 
   /** The list of correct answers for each invocation, computed by evaluating the challenge source code. */
-  val correctAnswers get() = functionInfo().correctAnswers
+  suspend fun correctAnswers() = functionInfo().correctAnswers
 
   /** Source file name. Defaults to `challengeName.suffix` but can be overridden in the DSL. */
   var fileName = "$challengeName.${languageType.suffix}"
@@ -133,11 +134,14 @@ sealed class Challenge(
   /** Computes an MD5 hash uniquely identifying a specific invocation of this challenge. */
   fun md5(invocation: Invocation) = md5Of(languageName, groupName, challengeName, invocation)
 
-  private fun measureParsing(code: String) =
+  // computeFunctionInfo is suspend (the script-pool engine borrow suspends), so this awaits it
+  // directly instead of bridging through runBlocking. The blocking, CPU-bound script eval runs on
+  // Dispatchers.IO so it does not block a request-serving dispatcher thread.
+  private suspend fun measureParsing(code: String) =
     metrics.challengeParseDuration.labels(agentLaunchId(), languageType.toString()).startTimer()
       .let {
         try {
-          runBlocking { computeFunctionInfo(code) }
+          withContext(Dispatchers.IO) { computeFunctionInfo(code) }
         } finally {
           it.observeDuration()
         }
@@ -151,7 +155,7 @@ sealed class Challenge(
    * Retrieves or computes the [FunctionInfo] for this challenge. Results are cached when running
    * in production or test mode. Source code is fetched from the configured repo (local or remote).
    */
-  fun functionInfo() =
+  suspend fun functionInfo(): FunctionInfo =
     if (repo.remote) {
       // Compute outside computeIfAbsent's bin lock: the blocking network fetch + script eval must
       // not hold the ConcurrentHashMap lock. A rare race may compute twice, but putIfAbsent keeps one.
@@ -160,7 +164,7 @@ sealed class Challenge(
         val code =
           fetchSourceCodeFromCache() ?: try {
             val path = pathOf((repo as AbstractRepo).rawSourcePrefix, branchName, srcPath, fqName)
-            val (text, dur) = measureTimedValue { URL(path).readText() }
+            val (text, dur) = measureTimedValue { withContext(Dispatchers.IO) { URL(path).readText() } }
             logger.debug { """Fetched "${pathOf(groupName, fileName)}" in: $dur from: $path""" }
 
             if (isContentCachingEnabled()) {
@@ -175,7 +179,7 @@ sealed class Challenge(
         content.functionInfoMap.putIfAbsent(challengeId, funcInfo) ?: funcInfo
       }
     } else {
-      fun parseCode(): FunctionInfo {
+      suspend fun parseCode(): FunctionInfo {
         val fs = repo as FileSystemSource
         val file = fs.file(pathOf(fs.pathPrefix, srcPath, packageNameAsPath, fileName))
         logger.info { """Fetching "${file.fileName}" from "${Paths.get("").toAbsolutePath()}""" }

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ChallengePage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ChallengePage.kt
@@ -154,7 +154,7 @@ internal object ChallengePage {
   internal const val HEADER_COLOR = "#419DC1"
 
   /** Renders the challenge page HTML for the given challenge, including code, answer inputs, and teacher dashboard. */
-  fun RoutingContext.challengePage(
+  suspend fun RoutingContext.challengePage(
     content: ReadingBatContent,
     user: User?,
     challenge: Challenge,

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/ClassSummaryPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/ClassSummaryPage.kt
@@ -25,13 +25,8 @@ import com.readingbat.common.ClassCodeRepository.fetchEnrollees
 import com.readingbat.common.ClassCodeRepository.isNotValid
 import com.readingbat.common.ClassCodeRepository.toDisplayString
 import com.readingbat.common.Constants.CLASS_CODE_QP
-import com.readingbat.common.Constants.CORRECT_COLOR
 import com.readingbat.common.Constants.GROUP_NAME_QP
-import com.readingbat.common.Constants.INCOMPLETE_COLOR
 import com.readingbat.common.Constants.LANG_TYPE_QP
-import com.readingbat.common.Constants.NO
-import com.readingbat.common.Constants.WRONG_COLOR
-import com.readingbat.common.Constants.YES
 import com.readingbat.common.Endpoints.CHALLENGE_ROOT
 import com.readingbat.common.Endpoints.CLASS_SUMMARY_ENDPOINT
 import com.readingbat.common.Endpoints.TEACHER_PREFS_ENDPOINT
@@ -64,6 +59,7 @@ import com.readingbat.pages.PageUtils.headDefault
 import com.readingbat.pages.PageUtils.loadPingdomScript
 import com.readingbat.pages.PageUtils.rawHtml
 import com.readingbat.pages.StudentSummaryPage.removeFromClassButton
+import com.readingbat.server.ChallengeName
 import com.readingbat.server.GroupName
 import com.readingbat.server.GroupName.Companion.EMPTY_GROUP
 import com.readingbat.server.LanguageName
@@ -108,7 +104,7 @@ internal object ClassSummaryPage {
   internal const val LIKE_DISLIKE = "-likeDislike"
   private const val BTN_SIZE = "130%"
 
-  fun RoutingContext.classSummaryPage(content: ReadingBatContent, user: User?): String {
+  suspend fun RoutingContext.classSummaryPage(content: ReadingBatContent, user: User?): String {
     val p = call.parameters
     val languageName = p[LANG_TYPE_QP]?.let { LanguageName(it) } ?: EMPTY_LANGUAGE
     val groupName = p[GROUP_NAME_QP]?.let { GroupName(it) } ?: EMPTY_GROUP
@@ -116,7 +112,7 @@ internal object ClassSummaryPage {
     return classSummaryPage(content, user, classCode, languageName, groupName)
   }
 
-  fun RoutingContext.classSummaryPage(
+  suspend fun RoutingContext.classSummaryPage(
     content: ReadingBatContent,
     user: User?,
     classCode: ClassCode,
@@ -140,6 +136,15 @@ internal object ClassSummaryPage {
           throw InvalidRequestException("User id ${user.userId} does not match class code's teacher id $teacherId")
       }
     }
+
+    // Pre-compute each challenge's invocation count before the (non-suspend) kotlinx.html builder,
+    // since functionInfo() suspends. Only the per-group detail view needs these.
+    val invocationCounts: Map<ChallengeName, Int> =
+      if (groupName.isDefined(content, languageName))
+        content.findGroup(languageName, groupName).challenges
+          .associate { it.challengeName to it.functionInfo().invocationCount }
+      else
+        emptyMap()
 
     return createHTML()
       .html {
@@ -179,7 +184,16 @@ internal object ClassSummaryPage {
           if (hasGroupName)
             displayGroupInfo(classCode, activeTeachingClassCode, languageName, groupName)
 
-          displayStudents(content, enrollees, classCode, activeTeachingClassCode, hasGroupName, languageName, groupName)
+          displayStudents(
+            content,
+            enrollees,
+            classCode,
+            activeTeachingClassCode,
+            hasGroupName,
+            languageName,
+            groupName,
+            invocationCounts,
+          )
 
           if (enrollees.isNotEmpty() && languageName.isValid() && groupName.isValid())
             enableWebSockets(languageName, groupName, classCode)
@@ -337,6 +351,7 @@ internal object ClassSummaryPage {
     hasGroup: Boolean,
     languageName: LanguageName,
     groupName: GroupName,
+    invocationCounts: Map<ChallengeName, Int>,
   ) =
     div(classes = TwClasses.INDENT_2EM) {
       val showDetail = hasGroup && classCode == activeClassCode
@@ -406,16 +421,15 @@ internal object ClassSummaryPage {
                           val encodedName = challenge.challengeName.encode()
                           tr {
                             style = "height:15px"
-                            challenge.functionInfo().invocations
-                              .forEachIndexed { i, _ ->
-                                td {
-                                  style = "padding:0; border:none"
-                                  div {
-                                    style = "width:7px; height:15px; border:1px solid black; background-color:#F1F1F1"
-                                    id = "${student.userId}-$encodedName-$i"
-                                  }
+                            repeat(invocationCounts[challenge.challengeName] ?: 0) { i ->
+                              td {
+                                style = "padding:0; border:none"
+                                div {
+                                  style = "width:7px; height:15px; border:1px solid black; background-color:#F1F1F1"
+                                  id = "${student.userId}-$encodedName-$i"
                                 }
                               }
+                            }
                             td(classes = TwClasses.INVOC_STAT) {
                               id = "${student.userId}-$encodedName$STATS"
                               +""

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/PlaygroundPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/PlaygroundPage.kt
@@ -56,18 +56,19 @@ import org.apache.commons.text.StringEscapeUtils.escapeHtml4
  * allowing users to edit and run Kotlin code directly in the browser.
  */
 internal object PlaygroundPage {
-  fun playgroundPage(
+  suspend fun playgroundPage(
     content: ReadingBatContent,
     user: User?,
     challenge: Challenge,
-  ) =
-    createHTML()
+  ): String {
+    // Computed before the (non-suspend) kotlinx.html builder, since functionInfo() suspends.
+    val funcInfo = challenge.functionInfo()
+    return createHTML()
       .html {
         val languageType = challenge.languageType
         val languageName = languageType.languageName
         val groupName = challenge.groupName
         val challengeName = challenge.challengeName
-        val funcInfo = challenge.functionInfo()
         val loginPath = pathOf(CHALLENGE_ROOT, languageName, groupName, challengeName)
         val activeTeachingClassCode = queryActiveTeachingClassCode(user)
 
@@ -124,4 +125,5 @@ internal object PlaygroundPage {
           loadPingdomScript()
         }
       }
+  }
 }

--- a/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
+++ b/readingbat-core/src/main/kotlin/com/readingbat/pages/StudentSummaryPage.kt
@@ -23,13 +23,8 @@ import com.readingbat.common.ClassCodeRepository.fetchClassTeacherId
 import com.readingbat.common.ClassCodeRepository.isNotValid
 import com.readingbat.common.ClassCodeRepository.toDisplayString
 import com.readingbat.common.Constants.CLASS_CODE_QP
-import com.readingbat.common.Constants.CORRECT_COLOR
-import com.readingbat.common.Constants.INCOMPLETE_COLOR
 import com.readingbat.common.Constants.LANG_TYPE_QP
-import com.readingbat.common.Constants.NO
 import com.readingbat.common.Constants.USER_ID_QP
-import com.readingbat.common.Constants.WRONG_COLOR
-import com.readingbat.common.Constants.YES
 import com.readingbat.common.Endpoints.CHALLENGE_ROOT
 import com.readingbat.common.Endpoints.STUDENT_SUMMARY_ENDPOINT
 import com.readingbat.common.Endpoints.TEACHER_PREFS_ENDPOINT
@@ -47,6 +42,7 @@ import com.readingbat.common.WsProtocol
 import com.readingbat.common.isNotValidUser
 import com.readingbat.dsl.InvalidRequestException
 import com.readingbat.dsl.ReadingBatContent
+import com.readingbat.dsl.challenge.Challenge
 import com.readingbat.pages.ChallengePage.HEADER_COLOR
 import com.readingbat.pages.ClassSummaryPage.LIKE_DISLIKE
 import com.readingbat.pages.ClassSummaryPage.STATS
@@ -93,7 +89,7 @@ import org.apache.commons.text.StringEscapeUtils.escapeEcmaScript
 internal object StudentSummaryPage {
   private val logger = KotlinLogging.logger {}
 
-  fun RoutingContext.studentSummaryPage(content: ReadingBatContent, user: User?): String {
+  suspend fun RoutingContext.studentSummaryPage(content: ReadingBatContent, user: User?): String {
     val p = call.parameters
     val languageName = p[LANG_TYPE_QP]?.let { LanguageName(it) } ?: throw InvalidRequestException("Missing language")
     val student = p[USER_ID_QP]?.toUser() ?: throw InvalidRequestException("Missing user id")
@@ -117,6 +113,13 @@ internal object StudentSummaryPage {
           throw InvalidRequestException("User id ${user.userId} does not match class code's teacher Id $teacherId")
       }
     }
+
+    // Pre-compute each challenge's invocation count before the (non-suspend) kotlinx.html builder,
+    // since functionInfo() suspends. Keyed by Challenge identity to avoid cross-group name clashes.
+    val invocationCounts: Map<Challenge, Int> =
+      content.findLanguage(languageName).challengeGroups
+        .flatMap { it.challenges }
+        .associateWith { it.functionInfo().invocationCount }
 
     return createHTML()
       .html {
@@ -157,7 +160,7 @@ internal object StudentSummaryPage {
             this@body.removeFromClassButton(student, studentName)
           }
 
-          displayChallengeGroups(content, classCode, languageName)
+          displayChallengeGroups(content, classCode, languageName, invocationCounts)
           enableWebSockets(languageName, student, classCode)
           backLink(returnPath)
           loadPingdomScript()
@@ -195,6 +198,7 @@ internal object StudentSummaryPage {
     content: ReadingBatContent,
     @Suppress("UNUSED_PARAMETER") classCode: ClassCode,
     languageName: LanguageName,
+    invocationCounts: Map<Challenge, Int>,
   ) =
     div(classes = TwClasses.INDENT_2EM) {
       table(classes = TwClasses.INVOC_TABLE) {
@@ -231,13 +235,12 @@ internal object StudentSummaryPage {
                             val encodedGroup = group.groupName.encode()
                             val encodedName = challenge.challengeName.encode()
                             tr {
-                              challenge.functionInfo().invocations
-                                .forEachIndexed { i, _ ->
-                                  td(classes = TwClasses.INVOC_TD) {
-                                    id = "$encodedGroup-$encodedName-$i"
-                                    +""
-                                  }
+                              repeat(invocationCounts[challenge] ?: 0) { i ->
+                                td(classes = TwClasses.INVOC_TD) {
+                                  id = "$encodedGroup-$encodedName-$i"
+                                  +""
                                 }
+                              }
                               td(classes = TwClasses.INVOC_STAT) {
                                 id = "$encodedGroup-$encodedName$STATS"
                                 +""

--- a/readingbat-core/src/test/kotlin/com/readingbat/posts/UserAnswersTest.kt
+++ b/readingbat-core/src/test/kotlin/com/readingbat/posts/UserAnswersTest.kt
@@ -79,8 +79,10 @@ class UserAnswersTest : StringSpec() {
           .forEachLanguage {
             forEachGroup {
               forEachChallenge {
+                // Compute in the suspend forEachChallenge scope; forEachAnswer's block is not suspend.
+                val answers = correctAnswers()
                 forEachAnswer {
-                  it shouldHaveAnswer correctAnswers[it.index]
+                  it shouldHaveAnswer answers[it.index]
                 }
               }
             }

--- a/readingbat-core/src/test/kotlin/website/TestSupportExamples.kt
+++ b/readingbat-core/src/test/kotlin/website/TestSupportExamples.kt
@@ -78,7 +78,7 @@ fun iterateContentExample() {
 // --8<-- [end:iterate_content]
 
 // --8<-- [start:access_challenges]
-fun accessChallengesExample() {
+suspend fun accessChallengesExample() {
   initTestProperties()
   val content = testContent
 

--- a/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
+++ b/readingbat-kotest/src/main/kotlin/com/readingbat/kotest/TestSupport.kt
@@ -98,7 +98,7 @@ object TestSupport {
       CHALLENGE_SRC to challengeName.value,
     )
 
-  private fun Challenge.parseChallengeResults(content: String): List<ChallengeResult> {
+  private suspend fun Challenge.parseChallengeResults(content: String): List<ChallengeResult> {
     var cnt = 0
     return Json.decodeFromString<JsonArray>(content)
       .map { v ->
@@ -141,14 +141,23 @@ object TestSupport {
     parseChallengeResults(content).forAll { it.block() }
   }
 
-  fun ReadingBatContent.pythonChallenge(groupName: String, challengeName: String, block: FunctionInfo.() -> Unit) =
-    pythonGroup(groupName).functionInfo(challengeName).apply(block)
+  suspend fun ReadingBatContent.pythonChallenge(
+    groupName: String,
+    challengeName: String,
+    block: FunctionInfo.() -> Unit,
+  ) = pythonGroup(groupName).functionInfo(challengeName).apply(block)
 
-  fun ReadingBatContent.javaChallenge(groupName: String, challengeName: String, block: FunctionInfo.() -> Unit) =
-    javaGroup(groupName).functionInfo(challengeName).apply(block)
+  suspend fun ReadingBatContent.javaChallenge(
+    groupName: String,
+    challengeName: String,
+    block: FunctionInfo.() -> Unit,
+  ) = javaGroup(groupName).functionInfo(challengeName).apply(block)
 
-  fun ReadingBatContent.kotlinChallenge(groupName: String, challengeName: String, block: FunctionInfo.() -> Unit) =
-    kotlinGroup(groupName).functionInfo(challengeName).apply(block)
+  suspend fun ReadingBatContent.kotlinChallenge(
+    groupName: String,
+    challengeName: String,
+    block: FunctionInfo.() -> Unit,
+  ) = kotlinGroup(groupName).functionInfo(challengeName).apply(block)
 
   fun ReadingBatContent.pythonGroup(name: String) = python[name]
 
@@ -159,7 +168,7 @@ object TestSupport {
   fun <T : Challenge> ChallengeGroup<T>.challengeByName(name: String) =
     challenges.firstOrNull { it.challengeName.value == name } ?: error("Missing challenge $name")
 
-  fun <T : Challenge> ChallengeGroup<T>.functionInfo(name: String) = challengeByName(name).functionInfo()
+  suspend fun <T : Challenge> ChallengeGroup<T>.functionInfo(name: String) = challengeByName(name).functionInfo()
 
   fun FunctionInfo.checkAnswer(index: Int, userResponse: String) =
     runBlocking {
@@ -168,7 +177,7 @@ object TestSupport {
 
   fun FunctionInfo.answerFor(index: Int) = ChallengeAnswer(this, index)
 
-  fun Challenge.forEachAnswer(block: (ChallengeAnswer) -> Unit) =
+  suspend fun Challenge.forEachAnswer(block: (ChallengeAnswer) -> Unit) =
     functionInfo().apply {
       (0 until questionCount).toList().forAll { i -> block(ChallengeAnswer(this, i)) }
     }


### PR DESCRIPTION
## Problem
`Challenge.functionInfo()` wrapped the `suspend computeFunctionInfo()` in `runBlocking` (`Challenge.kt:140`). Because `functionInfo()` is called from coroutine contexts (the WebSocket handlers' `collect{}` blocks, the answer-submit POST handlers, and `ReadingBatContent.load()`), that `runBlocking` blocked a request-serving dispatcher thread and is a deadlock/thread-starvation foot-gun.

## Change
- `functionInfo()` and `measureParsing()` are now `suspend`; the blocking, CPU-bound JSR-223 script eval runs on `Dispatchers.IO`, and the remote source fetch (`URL.readText`) is offloaded to IO too.
- `correctAnswers` becomes a `suspend fun` (a property getter can't suspend).
- The four challenge/summary page entry points are now `suspend`. This is unlocked by the suspend-block `respondWith` overload in **common-utils 2.9.2**:
  - `ChallengePage` / `PlaygroundPage` simply hoist the `functionInfo()` call above the kotlinx.html builder.
  - `ClassSummaryPage` / `StudentSummaryPage` pre-compute a per-challenge invocation-count map before the builder (the calls were inside non-suspend `table{}` loops) — the same data/render split pattern used elsewhere.
- **No changes needed** for the WS handlers, `ChallengePost`, or `ReadingBatContent.load()` — they were already in coroutine/suspend contexts and just recompile.
- `TestSupport` helpers that call `functionInfo()` become `suspend` (transparent at Kotest call sites); `UserAnswersTest` hoists `correctAnswers()` into the suspend `forEachChallenge` scope.

Bumps `common-utils` to `2.9.2` for the suspend-block `respondWith`/`redirectTo` overloads (a safe widening — existing non-suspend `respondWith { }` call sites still compile).

## Verification
`EndpointTest` (DB-backed, testcontainers) passes — both "Simple endpoint tests" and "Test all challenges" — on a forced re-run. Lint + detekt clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)